### PR TITLE
Add `wwtdatatool wtml rewrite-disk`

### DIFF
--- a/docs/api/wwt_data_formats.cli.wtml_rewrite_disk.rst
+++ b/docs/api/wwt_data_formats.cli.wtml_rewrite_disk.rst
@@ -1,0 +1,6 @@
+wtml_rewrite_disk
+=================
+
+.. currentmodule:: wwt_data_formats.cli
+
+.. autofunction:: wtml_rewrite_disk

--- a/docs/api/wwt_data_formats.folder.make_filesystem_url_mutator.rst
+++ b/docs/api/wwt_data_formats.folder.make_filesystem_url_mutator.rst
@@ -1,0 +1,6 @@
+make_filesystem_url_mutator
+===========================
+
+.. currentmodule:: wwt_data_formats.folder
+
+.. autofunction:: make_filesystem_url_mutator

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -12,4 +12,5 @@ CLI Reference
    cli/cabinet-unpack
    cli/serve
    cli/wtml-merge
+   cli/wtml-rewrite-disk
    cli/wtml-rewrite-urls

--- a/docs/cli/wtml-rewrite-disk.rst
+++ b/docs/cli/wtml-rewrite-disk.rst
@@ -1,0 +1,48 @@
+.. _cli-wtml-rewrite-disk:
+
+=================================
+``wwtdatatool wtml rewrite-disk``
+=================================
+
+The ``rewrite-disk`` subcommand takes a template `WTML`_ file populated with
+`relative URLs`_ and writes out a new file in which they have been changed to
+absolute paths on the local disk. Such a file is useful because it can be opened
+in the WWT desktop application.
+
+.. _WTML: https://docs.worldwidetelescope.org/data-guide/1/data-file-formats/collections/
+.. _relative URLs: https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL
+
+Usage
+=====
+
+.. code-block:: shell
+
+   wwtdatatool wtml rewrite-disk {INPUT-WTML} {OUTPUT-WTML}
+
+- The ``INPUT-WTML`` argument is the path to an input WTML file that may contain
+  relative disk for some of its data references.
+- The ``OUTPUT-WTML`` argument is the path where the modified output WTML
+  file will be written.
+
+Example
+=======
+
+In typical usage, it is expected that you’re preparing a data set for
+use in WWT. Using a tool like `toasty`_, you’ve created data files and a WTML
+file named ``index_rel.wtml`` describing them. This file contains relative data
+URLs, which are useful for data preparation but not allowed by the WWT apps. To
+test your WTML by opening it in the Windows app, you might run:
+
+.. code-block:: shell
+
+   wwtdatatool wtml rewrite-disk index_rel.wtml local.wtml
+
+Then you’d open ``local.wtml`` in the WWT desktop application to see how your
+data look.
+
+.. _toasty: https://toasty.readthedocs.io/
+
+See Also
+========
+
+- :ref:`cli-serve`

--- a/wwt_data_formats/cli.py
+++ b/wwt_data_formats/cli.py
@@ -292,6 +292,18 @@ def wtml_getparser(parser):
         help = 'The path to the output WTML file.',
     )
 
+    p = subparsers.add_parser('rewrite-disk')
+    p.add_argument(
+        'in_path',
+        metavar = 'INPUT-WTML',
+        help = 'The path to the input WTML file.',
+    )
+    p.add_argument(
+        'out_path',
+        metavar = 'OUTPUT-WTML',
+        help = 'The path of the rewritten, output WTML file.',
+    )
+
     p = subparsers.add_parser('rewrite-urls')
     p.add_argument(
         'in_path',
@@ -317,6 +329,8 @@ def wtml_impl(settings):
 
     if settings.wtml_command == 'merge':
         return wtml_merge(settings)
+    elif settings.wtml_command == 'rewrite-disk':
+        return wtml_rewrite_disk(settings)
     elif settings.wtml_command == 'rewrite-urls':
         return wtml_rewrite_urls(settings)
     else:
@@ -359,6 +373,21 @@ def wtml_merge(settings):
 
     with open(settings.out_path, 'wt', encoding='utf8') as f_out:
         out_folder.write_xml(f_out)
+
+
+def wtml_rewrite_disk(settings):
+    from .folder import Folder, make_filesystem_url_mutator
+
+    # Note that data URLs should be relative to the *source* WTML, which is why
+    # we're basing against in_path, not out_path.
+    rootdir = os.path.abspath(os.path.dirname(settings.in_path))
+    mutator = make_filesystem_url_mutator(rootdir)
+
+    f = Folder.from_file(settings.in_path)
+    f.mutate_urls(mutator)
+
+    with open(settings.out_path, 'wt', encoding='utf8') as f_out:
+        f.write_xml(f_out)
 
 
 def wtml_rewrite_urls(settings):

--- a/wwt_data_formats/folder.py
+++ b/wwt_data_formats/folder.py
@@ -8,6 +8,7 @@ __all__ = '''
 Folder
 fetch_folder_tree
 make_absolutizing_url_mutator
+make_filesystem_url_mutator
 walk_cached_folder_tree
 '''.split()
 
@@ -118,6 +119,44 @@ def make_absolutizing_url_mutator(baseurl):
         if urlsplit(url).netloc:
             return url  # this URL is absolute
         return urljoin(baseurl, url)
+
+    return mutator
+
+
+def make_filesystem_url_mutator(basedir):
+    """Return a function that converts relative URLs to filesystem paths.
+
+    Parameters
+    ----------
+    basedir : string, path
+        An absolute path that the relative URLs will be combined with.
+
+    Returns
+    -------
+    A mutator function suitable for use with
+    :meth:`wwt_data_formats.abcs.UrlContainer.mutate_urls`.
+
+    Notes
+    -----
+    This function is designed for usage with
+    :meth:`wwt_data_formats.abcs.UrlContainer.mutate_urls`. It returns a mutator
+    function that can be passed to this method. The mutator will take relative
+    URLs and convert them to filesystem paths by combining them with the
+    *basedir* argument. Input URLs that are absolute will be unchanged.
+
+    """
+    from urllib.parse import unquote, urlsplit
+
+    def mutator(url):
+        if not url:
+            return url
+
+        split = urlsplit(url)
+        if split.netloc:
+            return url  # this URL is absolute
+
+        # TODO: this should work with '..' but pretty much only by luck
+        return os.path.join(basedir, *(unquote(s) for s in split.path.split('/')))
 
     return mutator
 

--- a/wwt_data_formats/tests/test_folder.py
+++ b/wwt_data_formats/tests/test_folder.py
@@ -186,7 +186,7 @@ def test_wtml_rewrite_disk(in_tempdir):
     cli.entrypoint(['wtml', 'rewrite-disk', 'index_rel.wtml', 'index_disk.wtml'])
 
     f = folder.Folder.from_file('index_disk.wtml')
-    assert f.url == os.path.join(in_tempdir, 'sub dir', 'image.jpg')
+    assert f.url == os.path.join(os.path.abspath(in_tempdir), 'sub dir', 'image.jpg')
 
 
 def test_wtml_rewrite_urls(in_tempdir):

--- a/wwt_data_formats/tests/test_folder.py
+++ b/wwt_data_formats/tests/test_folder.py
@@ -186,7 +186,10 @@ def test_wtml_rewrite_disk(in_tempdir):
     cli.entrypoint(['wtml', 'rewrite-disk', 'index_rel.wtml', 'index_disk.wtml'])
 
     f = folder.Folder.from_file('index_disk.wtml')
-    assert f.url == os.path.join(os.path.abspath(in_tempdir), 'sub dir', 'image.jpg')
+    # We need to use realpath() here, not abspath() as used in the CLI, due to
+    # the way that on macOS the tempdir is in /var which is a symlink to
+    # /private/var.
+    assert f.url == os.path.join(os.path.realpath(in_tempdir), 'sub dir', 'image.jpg')
 
 
 def test_wtml_rewrite_urls(in_tempdir):

--- a/wwt_data_formats/tests/test_folder.py
+++ b/wwt_data_formats/tests/test_folder.py
@@ -186,10 +186,9 @@ def test_wtml_rewrite_disk(in_tempdir):
     cli.entrypoint(['wtml', 'rewrite-disk', 'index_rel.wtml', 'index_disk.wtml'])
 
     f = folder.Folder.from_file('index_disk.wtml')
-    # We need to use realpath() here, not abspath() as used in the CLI, due to
-    # the way that on macOS the tempdir is in /var which is a symlink to
-    # /private/var.
-    assert f.url == os.path.join(os.path.realpath(in_tempdir), 'sub dir', 'image.jpg')
+    # abspath('') is not necessarily equal to abspath(in_tempdir), due to
+    # symlinks and Windows filename shorterning.
+    assert f.url == os.path.join(os.path.abspath(''), 'sub dir', 'image.jpg')
 
 
 def test_wtml_rewrite_urls(in_tempdir):

--- a/wwt_data_formats/tests/test_folder.py
+++ b/wwt_data_formats/tests/test_folder.py
@@ -22,6 +22,15 @@ def tempdir():
     shutil.rmtree(d)
 
 
+@pytest.fixture
+def in_tempdir(tempdir):
+    prev_dir = os.getcwd()
+    os.chdir(tempdir)
+    yield tempdir
+    # Windows can't remove the temp tree unless we chdir out of it.
+    os.chdir(prev_dir)
+
+
 BASIC_XML_STRING = '''
 <Folder MSRCommunityId="0" MSRComponentId="0" Permission="0"
         Browseable="True" Group="Explorer" Searchable="True" Type="Sky" />
@@ -167,10 +176,20 @@ def test_basic_url_mutation():
     assert imgset.url == 'https://example.com/subdir/image.jpg'
 
 
-def test_wtml_rewrite_urls(tempdir):
-    prev_dir = os.getcwd()
-    os.chdir(tempdir)
+def test_wtml_rewrite_disk(in_tempdir):
+    f = folder.Folder()
+    f.url = 'sub%20dir/image.jpg'
 
+    with open('index_rel.wtml', 'wt', encoding='utf8') as f_out:
+        f.write_xml(f_out)
+
+    cli.entrypoint(['wtml', 'rewrite-disk', 'index_rel.wtml', 'index_disk.wtml'])
+
+    f = folder.Folder.from_file('index_disk.wtml')
+    assert f.url == os.path.join(in_tempdir, 'sub dir', 'image.jpg')
+
+
+def test_wtml_rewrite_urls(in_tempdir):
     f = folder.Folder()
     f.url = '../updir/somewhere.wtml'
 
@@ -181,6 +200,3 @@ def test_wtml_rewrite_urls(tempdir):
 
     f = folder.Folder.from_file('index.wtml')
     assert f.url == 'https://example.com/updir/somewhere.wtml'
-
-    # Windows can't remove the temp tree unless we chdir out of it.
-    os.chdir(prev_dir)

--- a/wwt_data_formats/tests/test_imageset.py
+++ b/wwt_data_formats/tests/test_imageset.py
@@ -124,13 +124,7 @@ def test_misc_ser():
     observed_text = imgset.to_xml_string()
     assert observed_text == expected_text
 
-    from io import StringIO, BytesIO
-
-    expected_strio = StringIO()
-    observed_strio = StringIO()
-    write_xml_doc(expected_xml, dest_stream=expected_strio, indent=False)
-    imgset.write_xml(observed_strio, indent=False)
-    assert observed_strio.getvalue() == expected_strio.getvalue()
+    from io import BytesIO
 
     expected_bio = BytesIO()
     observed_bio = BytesIO()

--- a/wwt_data_formats/tests/test_imageset.py
+++ b/wwt_data_formats/tests/test_imageset.py
@@ -131,3 +131,4 @@ def test_misc_ser():
     write_xml_doc(expected_xml, dest_stream=expected_bio, dest_wants_bytes=True)
     imgset.write_xml(observed_bio, dest_wants_bytes=True)
     assert observed_bio.getvalue() == expected_bio.getvalue()
+    assert b'encoding=\'UTF-8\'' in observed_bio.getvalue()


### PR DESCRIPTION
This rewrites an index_rel.wtml file to insert absolute filesystem paths, allowing you to open up your data in the Windows app.