### PR TITLE
wwt_data_formats/imageset.py: fix calculation of the image center

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -88,7 +88,7 @@ jobs:
       source activate-conda.sh
       conda activate build
       set -x
-      \conda install -y mock numpy pytest-cov pytest-mock
+      \conda install -y astropy mock numpy pytest-cov pytest-mock
       pytest --cov-report=xml --cov=wwt_data_formats wwt_data_formats
     displayName: Test with coverage
 

--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -328,7 +328,7 @@ class ImageSet(LockedXmlTraits, UrlContainer):
             center_dec_deg = dec_deg
         else:
             wcs = WCS(headers)
-            center = wcs.pixel_to_world(height / 2, width / 2)
+            center = wcs.pixel_to_world(width / 2, height / 2)
             center_ra_deg = center.ra.deg
             center_dec_deg = center.dec.deg
 


### PR DESCRIPTION
I had my X and Y flipped!

(BTW, this logic won't work great if the image has masked pixels and those pixels are asymmetrically distributed around its barycenter. The fancier approach would be to compute the effective pixel center from the barycenter of the mask.)