### PR TITLE
Add `Place.description`.

### DIFF
--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -196,7 +196,13 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     """A URL to a standard WWT thumbnail representation of this imageset."""
 
     description = Unicode('').tag(xml=XmlSer.text_elem('Description'))
-    """A textual description of the imagery."""
+    """
+    A textual description of the imagery.
+
+    This field is referenced a few times in the original WWT documentation, but
+    is not actually implemented. The ``Place.description`` field is at least
+    loaded from the XML.
+    """
 
     msr_community_id = Int(0).tag(xml=XmlSer.attr('MSRCommunityId'))
     """The ID number of the WWT Community that this content came from."""

--- a/wwt_data_formats/place.py
+++ b/wwt_data_formats/place.py
@@ -52,6 +52,15 @@ class Place(LockedXmlTraits, UrlContainer):
     foreground_image_set = Instance(ImageSet, allow_none=True).tag(xml=XmlSer.wrapped_inner('ForegroundImageSet'))
     image_set = Instance(ImageSet, allow_none=True).tag(xml=XmlSer.inner('ImageSet'))
     thumbnail = Unicode('').tag(xml=XmlSer.attr('Thumbnail'))
+
+    description = Unicode('').tag(xml=XmlSer.text_elem('Description'))
+    """
+    A description of the place, using HTML markup.
+
+    This field is not actually used in the stock WWT clients, but it is wired up
+    and loaded from the XML.
+    """
+
     msr_community_id = Int(0).tag(xml=XmlSer.attr('MSRCommunityId'))
     """The ID number of the WWT Community that this content came from."""
 


### PR DESCRIPTION
Oh hey, it turns out that the `ImageSet.description` field is not actually used in WWT! It appears in some of the files and docs, but the engine and Windows client don't actually load it. The stock clients don't do anything with `Place.description` either, but at least they load it.