### PR TITLE
Support glob arguments on Windows

### DIFF
--- a/docs/api/wwt_data_formats.cli.EnsureGlobsExpandedAction.rst
+++ b/docs/api/wwt_data_formats.cli.EnsureGlobsExpandedAction.rst
@@ -1,0 +1,19 @@
+EnsureGlobsExpandedAction
+=========================
+
+.. currentmodule:: wwt_data_formats.cli
+
+.. autoclass:: EnsureGlobsExpandedAction
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~EnsureGlobsExpandedAction.__call__
+      ~EnsureGlobsExpandedAction.expand_globs
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: __call__
+   .. automethod:: expand_globs


### PR DESCRIPTION
On Windows, the basic command prompt doesn't expand globs. It turns out that if you want to support globs on this OS, you have to ... just manually implement them. Annoying! But not so hard to do.

Note that we can't implement this as a `type` keyword because it operates item-by-item, so it can't conveniently turn one item into many. I think.