### PR TITLE
Work around missing members in the API documentation

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -117,7 +117,7 @@ jobs:
       source activate-conda.sh
       conda activate build
       set -x
-      \conda install -y astropy numpydoc sphinx sphinx-automodapi
+      \conda install -y astropy graphviz numpydoc sphinx sphinx-automodapi
       pip install astropy-sphinx-theme
       cd docs
       make html

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,7 +18,7 @@ API Reference
 
 .. automodapi:: wwt_data_formats.cli
    :no-inheritance-diagram:
-   :inherited-members:
+   :no-inherited-members:
 
 .. automodapi:: wwt_data_formats.enums
    :no-inheritance-diagram:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,42 +2,48 @@
 API Reference
 =============
 
+..
+   Working around https://github.com/astropy/sphinx-automodapi/issues/132 : Our
+   API docs were missing members for classes like ImageSet due to an esoteric
+   bug related to ABCs (June 2021, sphinx-automodapi 0.13). Work around by
+   forcing `:inherited-members:`, and do it everywhere to avoid any oversights.
+
 .. automodapi:: wwt_data_formats
-   :no-inheritance-diagram:
-   :no-inherited-members:
+   :inheritance-diagram:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.abcs
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.cli
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.enums
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.filecabinet
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.folder
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.imageset
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.layers
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.place
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:
 
 .. automodapi:: wwt_data_formats.server
    :no-inheritance-diagram:
-   :no-inherited-members:
+   :inherited-members:

--- a/docs/api/wwt_data_formats.LockedDownTraits.rst
+++ b/docs/api/wwt_data_formats.LockedDownTraits.rst
@@ -10,8 +10,60 @@ LockedDownTraits
 
    .. autosummary::
 
+      ~LockedDownTraits.cross_validation_lock
       ~LockedDownTraits.rmeta
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~LockedDownTraits.add_traits
+      ~LockedDownTraits.class_own_trait_events
+      ~LockedDownTraits.class_own_traits
+      ~LockedDownTraits.class_trait_names
+      ~LockedDownTraits.class_traits
+      ~LockedDownTraits.has_trait
+      ~LockedDownTraits.hold_trait_notifications
+      ~LockedDownTraits.notify_change
+      ~LockedDownTraits.observe
+      ~LockedDownTraits.on_trait_change
+      ~LockedDownTraits.set_trait
+      ~LockedDownTraits.setup_instance
+      ~LockedDownTraits.trait_defaults
+      ~LockedDownTraits.trait_events
+      ~LockedDownTraits.trait_has_value
+      ~LockedDownTraits.trait_metadata
+      ~LockedDownTraits.trait_names
+      ~LockedDownTraits.trait_values
+      ~LockedDownTraits.traits
+      ~LockedDownTraits.unobserve
+      ~LockedDownTraits.unobserve_all
 
    .. rubric:: Attributes Documentation
 
+   .. autoattribute:: cross_validation_lock
    .. autoattribute:: rmeta
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all

--- a/docs/api/wwt_data_formats.LockedXmlTraits.rst
+++ b/docs/api/wwt_data_formats.LockedXmlTraits.rst
@@ -6,26 +6,80 @@ LockedXmlTraits
 .. autoclass:: LockedXmlTraits
    :show-inheritance:
 
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~LockedXmlTraits.cross_validation_lock
+      ~LockedXmlTraits.rmeta
+
    .. rubric:: Methods Summary
 
    .. autosummary::
 
+      ~LockedXmlTraits.add_traits
       ~LockedXmlTraits.apply_to_xml
+      ~LockedXmlTraits.class_own_trait_events
+      ~LockedXmlTraits.class_own_traits
+      ~LockedXmlTraits.class_trait_names
+      ~LockedXmlTraits.class_traits
       ~LockedXmlTraits.from_file
       ~LockedXmlTraits.from_text
       ~LockedXmlTraits.from_url
       ~LockedXmlTraits.from_xml
+      ~LockedXmlTraits.has_trait
+      ~LockedXmlTraits.hold_trait_notifications
+      ~LockedXmlTraits.notify_change
+      ~LockedXmlTraits.observe
+      ~LockedXmlTraits.on_trait_change
+      ~LockedXmlTraits.set_trait
+      ~LockedXmlTraits.setup_instance
       ~LockedXmlTraits.to_xml
       ~LockedXmlTraits.to_xml_string
+      ~LockedXmlTraits.trait_defaults
+      ~LockedXmlTraits.trait_events
+      ~LockedXmlTraits.trait_has_value
+      ~LockedXmlTraits.trait_metadata
+      ~LockedXmlTraits.trait_names
+      ~LockedXmlTraits.trait_values
+      ~LockedXmlTraits.traits
+      ~LockedXmlTraits.unobserve
+      ~LockedXmlTraits.unobserve_all
       ~LockedXmlTraits.write_xml
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: cross_validation_lock
+   .. autoattribute:: rmeta
 
    .. rubric:: Methods Documentation
 
+   .. automethod:: add_traits
    .. automethod:: apply_to_xml
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
    .. automethod:: from_file
    .. automethod:: from_text
    .. automethod:: from_url
    .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
    .. automethod:: to_xml
    .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
    .. automethod:: write_xml

--- a/docs/api/wwt_data_formats.MetaLockedDownTraits.rst
+++ b/docs/api/wwt_data_formats.MetaLockedDownTraits.rst
@@ -5,3 +5,19 @@ MetaLockedDownTraits
 
 .. autoclass:: MetaLockedDownTraits
    :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~MetaLockedDownTraits.__call__
+      ~MetaLockedDownTraits.mro
+      ~MetaLockedDownTraits.register
+      ~MetaLockedDownTraits.setup_class
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: __call__
+   .. automethod:: mro
+   .. automethod:: register
+   .. automethod:: setup_class

--- a/docs/api/wwt_data_formats.XmlSer.rst
+++ b/docs/api/wwt_data_formats.XmlSer.rst
@@ -18,18 +18,6 @@ XmlSer
       ~XmlSer.WRAPPED_INNER
       ~XmlSer.WRAPPED_INNER_LIST
 
-   .. rubric:: Methods Summary
-
-   .. autosummary::
-
-      ~XmlSer.attr
-      ~XmlSer.inner
-      ~XmlSer.inner_list
-      ~XmlSer.ns_to_attr
-      ~XmlSer.text_elem
-      ~XmlSer.wrapped_inner
-      ~XmlSer.wrapped_inner_list
-
    .. rubric:: Attributes Documentation
 
    .. autoattribute:: ATTRIBUTE
@@ -39,13 +27,3 @@ XmlSer
    .. autoattribute:: TEXT_ELEM
    .. autoattribute:: WRAPPED_INNER
    .. autoattribute:: WRAPPED_INNER_LIST
-
-   .. rubric:: Methods Documentation
-
-   .. automethod:: attr
-   .. automethod:: inner
-   .. automethod:: inner_list
-   .. automethod:: ns_to_attr
-   .. automethod:: text_elem
-   .. automethod:: wrapped_inner
-   .. automethod:: wrapped_inner_list

--- a/docs/api/wwt_data_formats.cli.EnsureGlobsExpandedAction.rst
+++ b/docs/api/wwt_data_formats.cli.EnsureGlobsExpandedAction.rst
@@ -12,8 +12,10 @@ EnsureGlobsExpandedAction
 
       ~EnsureGlobsExpandedAction.__call__
       ~EnsureGlobsExpandedAction.expand_globs
+      ~EnsureGlobsExpandedAction.format_usage
 
    .. rubric:: Methods Documentation
 
    .. automethod:: __call__
    .. automethod:: expand_globs
+   .. automethod:: format_usage

--- a/docs/api/wwt_data_formats.cli.EnsureGlobsExpandedAction.rst
+++ b/docs/api/wwt_data_formats.cli.EnsureGlobsExpandedAction.rst
@@ -12,10 +12,8 @@ EnsureGlobsExpandedAction
 
       ~EnsureGlobsExpandedAction.__call__
       ~EnsureGlobsExpandedAction.expand_globs
-      ~EnsureGlobsExpandedAction.format_usage
 
    .. rubric:: Methods Documentation
 
    .. automethod:: __call__
    .. automethod:: expand_globs
-   .. automethod:: format_usage

--- a/docs/api/wwt_data_formats.enums.ProjectionType.rst
+++ b/docs/api/wwt_data_formats.enums.ProjectionType.rst
@@ -19,12 +19,6 @@ ProjectionType
       ~ProjectionType.TAN
       ~ProjectionType.TOAST
 
-   .. rubric:: Methods Summary
-
-   .. autosummary::
-
-      ~ProjectionType.from_text
-
    .. rubric:: Attributes Documentation
 
    .. autoattribute:: EQUIRECTANGULAR
@@ -35,7 +29,3 @@ ProjectionType
    .. autoattribute:: SPHERICAL
    .. autoattribute:: TAN
    .. autoattribute:: TOAST
-
-   .. rubric:: Methods Documentation
-
-   .. automethod:: from_text

--- a/docs/api/wwt_data_formats.enums.SerEnum.rst
+++ b/docs/api/wwt_data_formats.enums.SerEnum.rst
@@ -5,13 +5,3 @@ SerEnum
 
 .. autoclass:: SerEnum
    :show-inheritance:
-
-   .. rubric:: Methods Summary
-
-   .. autosummary::
-
-      ~SerEnum.from_text
-
-   .. rubric:: Methods Documentation
-
-   .. automethod:: from_text

--- a/docs/api/wwt_data_formats.folder.Folder.rst
+++ b/docs/api/wwt_data_formats.folder.Folder.rst
@@ -5,3 +5,109 @@ Folder
 
 .. autoclass:: Folder
    :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Folder.browseable
+      ~Folder.children
+      ~Folder.cross_validation_lock
+      ~Folder.group
+      ~Folder.msr_community_id
+      ~Folder.msr_component_id
+      ~Folder.name
+      ~Folder.permission
+      ~Folder.rmeta
+      ~Folder.searchable
+      ~Folder.sub_type
+      ~Folder.thumbnail
+      ~Folder.type
+      ~Folder.url
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Folder.add_traits
+      ~Folder.apply_to_xml
+      ~Folder.class_own_trait_events
+      ~Folder.class_own_traits
+      ~Folder.class_trait_names
+      ~Folder.class_traits
+      ~Folder.from_file
+      ~Folder.from_text
+      ~Folder.from_url
+      ~Folder.from_xml
+      ~Folder.has_trait
+      ~Folder.hold_trait_notifications
+      ~Folder.mutate_urls
+      ~Folder.notify_change
+      ~Folder.observe
+      ~Folder.on_trait_change
+      ~Folder.set_trait
+      ~Folder.setup_instance
+      ~Folder.to_xml
+      ~Folder.to_xml_string
+      ~Folder.trait_defaults
+      ~Folder.trait_events
+      ~Folder.trait_has_value
+      ~Folder.trait_metadata
+      ~Folder.trait_names
+      ~Folder.trait_values
+      ~Folder.traits
+      ~Folder.unobserve
+      ~Folder.unobserve_all
+      ~Folder.walk
+      ~Folder.write_xml
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: browseable
+   .. autoattribute:: children
+   .. autoattribute:: cross_validation_lock
+   .. autoattribute:: group
+   .. autoattribute:: msr_community_id
+   .. autoattribute:: msr_component_id
+   .. autoattribute:: name
+   .. autoattribute:: permission
+   .. autoattribute:: rmeta
+   .. autoattribute:: searchable
+   .. autoattribute:: sub_type
+   .. autoattribute:: thumbnail
+   .. autoattribute:: type
+   .. autoattribute:: url
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: apply_to_xml
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: from_file
+   .. automethod:: from_text
+   .. automethod:: from_url
+   .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: mutate_urls
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: to_xml
+   .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
+   .. automethod:: walk
+   .. automethod:: write_xml

--- a/docs/api/wwt_data_formats.imageset.ImageSet.rst
+++ b/docs/api/wwt_data_formats.imageset.ImageSet.rst
@@ -5,3 +5,151 @@ ImageSet
 
 .. autoclass:: ImageSet
    :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~ImageSet.alt_url
+      ~ImageSet.band_pass
+      ~ImageSet.base_degrees_per_tile
+      ~ImageSet.base_tile_level
+      ~ImageSet.bottoms_up
+      ~ImageSet.center_x
+      ~ImageSet.center_y
+      ~ImageSet.credits
+      ~ImageSet.credits_url
+      ~ImageSet.cross_validation_lock
+      ~ImageSet.data_set_type
+      ~ImageSet.dem_url
+      ~ImageSet.description
+      ~ImageSet.elevation_model
+      ~ImageSet.file_type
+      ~ImageSet.generic
+      ~ImageSet.mean_radius
+      ~ImageSet.msr_community_id
+      ~ImageSet.msr_component_id
+      ~ImageSet.name
+      ~ImageSet.offset_x
+      ~ImageSet.offset_y
+      ~ImageSet.permission
+      ~ImageSet.projection
+      ~ImageSet.quad_tree_map
+      ~ImageSet.reference_frame
+      ~ImageSet.rmeta
+      ~ImageSet.rotation_deg
+      ~ImageSet.sparse
+      ~ImageSet.stock_set
+      ~ImageSet.thumbnail_url
+      ~ImageSet.tile_levels
+      ~ImageSet.url
+      ~ImageSet.width_factor
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~ImageSet.add_traits
+      ~ImageSet.apply_to_xml
+      ~ImageSet.class_own_trait_events
+      ~ImageSet.class_own_traits
+      ~ImageSet.class_trait_names
+      ~ImageSet.class_traits
+      ~ImageSet.from_file
+      ~ImageSet.from_text
+      ~ImageSet.from_url
+      ~ImageSet.from_xml
+      ~ImageSet.has_trait
+      ~ImageSet.hold_trait_notifications
+      ~ImageSet.mutate_urls
+      ~ImageSet.notify_change
+      ~ImageSet.observe
+      ~ImageSet.on_trait_change
+      ~ImageSet.set_position_from_wcs
+      ~ImageSet.set_trait
+      ~ImageSet.setup_instance
+      ~ImageSet.to_xml
+      ~ImageSet.to_xml_string
+      ~ImageSet.trait_defaults
+      ~ImageSet.trait_events
+      ~ImageSet.trait_has_value
+      ~ImageSet.trait_metadata
+      ~ImageSet.trait_names
+      ~ImageSet.trait_values
+      ~ImageSet.traits
+      ~ImageSet.unobserve
+      ~ImageSet.unobserve_all
+      ~ImageSet.wcs_headers_from_position
+      ~ImageSet.write_xml
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: alt_url
+   .. autoattribute:: band_pass
+   .. autoattribute:: base_degrees_per_tile
+   .. autoattribute:: base_tile_level
+   .. autoattribute:: bottoms_up
+   .. autoattribute:: center_x
+   .. autoattribute:: center_y
+   .. autoattribute:: credits
+   .. autoattribute:: credits_url
+   .. autoattribute:: cross_validation_lock
+   .. autoattribute:: data_set_type
+   .. autoattribute:: dem_url
+   .. autoattribute:: description
+   .. autoattribute:: elevation_model
+   .. autoattribute:: file_type
+   .. autoattribute:: generic
+   .. autoattribute:: mean_radius
+   .. autoattribute:: msr_community_id
+   .. autoattribute:: msr_component_id
+   .. autoattribute:: name
+   .. autoattribute:: offset_x
+   .. autoattribute:: offset_y
+   .. autoattribute:: permission
+   .. autoattribute:: projection
+   .. autoattribute:: quad_tree_map
+   .. autoattribute:: reference_frame
+   .. autoattribute:: rmeta
+   .. autoattribute:: rotation_deg
+   .. autoattribute:: sparse
+   .. autoattribute:: stock_set
+   .. autoattribute:: thumbnail_url
+   .. autoattribute:: tile_levels
+   .. autoattribute:: url
+   .. autoattribute:: width_factor
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: apply_to_xml
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: from_file
+   .. automethod:: from_text
+   .. automethod:: from_url
+   .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: mutate_urls
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_position_from_wcs
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: to_xml
+   .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
+   .. automethod:: wcs_headers_from_position
+   .. automethod:: write_xml

--- a/docs/api/wwt_data_formats.layers.ImageSetLayer.rst
+++ b/docs/api/wwt_data_formats.layers.ImageSetLayer.rst
@@ -10,12 +10,92 @@ ImageSetLayer
 
    .. autosummary::
 
+      ~ImageSetLayer.cross_validation_lock
       ~ImageSetLayer.extension
+      ~ImageSetLayer.id
       ~ImageSetLayer.image_set
+      ~ImageSetLayer.layer_type
+      ~ImageSetLayer.name
+      ~ImageSetLayer.opacity
       ~ImageSetLayer.override_default
+      ~ImageSetLayer.reference_frame
+      ~ImageSetLayer.rmeta
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~ImageSetLayer.add_traits
+      ~ImageSetLayer.apply_to_xml
+      ~ImageSetLayer.class_own_trait_events
+      ~ImageSetLayer.class_own_traits
+      ~ImageSetLayer.class_trait_names
+      ~ImageSetLayer.class_traits
+      ~ImageSetLayer.from_file
+      ~ImageSetLayer.from_text
+      ~ImageSetLayer.from_url
+      ~ImageSetLayer.from_xml
+      ~ImageSetLayer.has_trait
+      ~ImageSetLayer.hold_trait_notifications
+      ~ImageSetLayer.notify_change
+      ~ImageSetLayer.observe
+      ~ImageSetLayer.on_trait_change
+      ~ImageSetLayer.set_trait
+      ~ImageSetLayer.setup_instance
+      ~ImageSetLayer.to_xml
+      ~ImageSetLayer.to_xml_string
+      ~ImageSetLayer.trait_defaults
+      ~ImageSetLayer.trait_events
+      ~ImageSetLayer.trait_has_value
+      ~ImageSetLayer.trait_metadata
+      ~ImageSetLayer.trait_names
+      ~ImageSetLayer.trait_values
+      ~ImageSetLayer.traits
+      ~ImageSetLayer.unobserve
+      ~ImageSetLayer.unobserve_all
+      ~ImageSetLayer.write_xml
 
    .. rubric:: Attributes Documentation
 
+   .. autoattribute:: cross_validation_lock
    .. autoattribute:: extension
+   .. autoattribute:: id
    .. autoattribute:: image_set
+   .. autoattribute:: layer_type
+   .. autoattribute:: name
+   .. autoattribute:: opacity
    .. autoattribute:: override_default
+   .. autoattribute:: reference_frame
+   .. autoattribute:: rmeta
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: apply_to_xml
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: from_file
+   .. automethod:: from_text
+   .. automethod:: from_url
+   .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: to_xml
+   .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
+   .. automethod:: write_xml

--- a/docs/api/wwt_data_formats.layers.Layer.rst
+++ b/docs/api/wwt_data_formats.layers.Layer.rst
@@ -10,16 +10,86 @@ Layer
 
    .. autosummary::
 
+      ~Layer.cross_validation_lock
       ~Layer.id
       ~Layer.layer_type
       ~Layer.name
       ~Layer.opacity
       ~Layer.reference_frame
+      ~Layer.rmeta
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Layer.add_traits
+      ~Layer.apply_to_xml
+      ~Layer.class_own_trait_events
+      ~Layer.class_own_traits
+      ~Layer.class_trait_names
+      ~Layer.class_traits
+      ~Layer.from_file
+      ~Layer.from_text
+      ~Layer.from_url
+      ~Layer.from_xml
+      ~Layer.has_trait
+      ~Layer.hold_trait_notifications
+      ~Layer.notify_change
+      ~Layer.observe
+      ~Layer.on_trait_change
+      ~Layer.set_trait
+      ~Layer.setup_instance
+      ~Layer.to_xml
+      ~Layer.to_xml_string
+      ~Layer.trait_defaults
+      ~Layer.trait_events
+      ~Layer.trait_has_value
+      ~Layer.trait_metadata
+      ~Layer.trait_names
+      ~Layer.trait_values
+      ~Layer.traits
+      ~Layer.unobserve
+      ~Layer.unobserve_all
+      ~Layer.write_xml
 
    .. rubric:: Attributes Documentation
 
+   .. autoattribute:: cross_validation_lock
    .. autoattribute:: id
    .. autoattribute:: layer_type
    .. autoattribute:: name
    .. autoattribute:: opacity
    .. autoattribute:: reference_frame
+   .. autoattribute:: rmeta
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: apply_to_xml
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: from_file
+   .. automethod:: from_text
+   .. automethod:: from_url
+   .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: to_xml
+   .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
+   .. automethod:: write_xml

--- a/docs/api/wwt_data_formats.layers.LayerContainerXml.rst
+++ b/docs/api/wwt_data_formats.layers.LayerContainerXml.rst
@@ -10,10 +10,80 @@ LayerContainerXml
 
    .. autosummary::
 
+      ~LayerContainerXml.cross_validation_lock
       ~LayerContainerXml.id
       ~LayerContainerXml.layers
+      ~LayerContainerXml.rmeta
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~LayerContainerXml.add_traits
+      ~LayerContainerXml.apply_to_xml
+      ~LayerContainerXml.class_own_trait_events
+      ~LayerContainerXml.class_own_traits
+      ~LayerContainerXml.class_trait_names
+      ~LayerContainerXml.class_traits
+      ~LayerContainerXml.from_file
+      ~LayerContainerXml.from_text
+      ~LayerContainerXml.from_url
+      ~LayerContainerXml.from_xml
+      ~LayerContainerXml.has_trait
+      ~LayerContainerXml.hold_trait_notifications
+      ~LayerContainerXml.notify_change
+      ~LayerContainerXml.observe
+      ~LayerContainerXml.on_trait_change
+      ~LayerContainerXml.set_trait
+      ~LayerContainerXml.setup_instance
+      ~LayerContainerXml.to_xml
+      ~LayerContainerXml.to_xml_string
+      ~LayerContainerXml.trait_defaults
+      ~LayerContainerXml.trait_events
+      ~LayerContainerXml.trait_has_value
+      ~LayerContainerXml.trait_metadata
+      ~LayerContainerXml.trait_names
+      ~LayerContainerXml.trait_values
+      ~LayerContainerXml.traits
+      ~LayerContainerXml.unobserve
+      ~LayerContainerXml.unobserve_all
+      ~LayerContainerXml.write_xml
 
    .. rubric:: Attributes Documentation
 
+   .. autoattribute:: cross_validation_lock
    .. autoattribute:: id
    .. autoattribute:: layers
+   .. autoattribute:: rmeta
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: apply_to_xml
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: from_file
+   .. automethod:: from_text
+   .. automethod:: from_url
+   .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: to_xml
+   .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
+   .. automethod:: write_xml

--- a/docs/api/wwt_data_formats.place.Place.rst
+++ b/docs/api/wwt_data_formats.place.Place.rst
@@ -5,3 +5,139 @@ Place
 
 .. autoclass:: Place
    :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~Place.angle
+      ~Place.angular_size
+      ~Place.annotation
+      ~Place.background_image_set
+      ~Place.classification
+      ~Place.constellation
+      ~Place.cross_validation_lock
+      ~Place.data_set_type
+      ~Place.dec_deg
+      ~Place.description
+      ~Place.distance
+      ~Place.dome_alt
+      ~Place.dome_az
+      ~Place.foreground_image_set
+      ~Place.image_set
+      ~Place.latitude
+      ~Place.longitude
+      ~Place.magnitude
+      ~Place.msr_community_id
+      ~Place.msr_component_id
+      ~Place.name
+      ~Place.opacity
+      ~Place.permission
+      ~Place.ra_hr
+      ~Place.rmeta
+      ~Place.rotation_deg
+      ~Place.thumbnail
+      ~Place.xmeta
+      ~Place.zoom_level
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~Place.add_traits
+      ~Place.apply_to_xml
+      ~Place.as_imageset
+      ~Place.class_own_trait_events
+      ~Place.class_own_traits
+      ~Place.class_trait_names
+      ~Place.class_traits
+      ~Place.from_file
+      ~Place.from_text
+      ~Place.from_url
+      ~Place.from_xml
+      ~Place.has_trait
+      ~Place.hold_trait_notifications
+      ~Place.mutate_urls
+      ~Place.notify_change
+      ~Place.observe
+      ~Place.on_trait_change
+      ~Place.set_trait
+      ~Place.setup_instance
+      ~Place.to_xml
+      ~Place.to_xml_string
+      ~Place.trait_defaults
+      ~Place.trait_events
+      ~Place.trait_has_value
+      ~Place.trait_metadata
+      ~Place.trait_names
+      ~Place.trait_values
+      ~Place.traits
+      ~Place.unobserve
+      ~Place.unobserve_all
+      ~Place.write_xml
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: angle
+   .. autoattribute:: angular_size
+   .. autoattribute:: annotation
+   .. autoattribute:: background_image_set
+   .. autoattribute:: classification
+   .. autoattribute:: constellation
+   .. autoattribute:: cross_validation_lock
+   .. autoattribute:: data_set_type
+   .. autoattribute:: dec_deg
+   .. autoattribute:: description
+   .. autoattribute:: distance
+   .. autoattribute:: dome_alt
+   .. autoattribute:: dome_az
+   .. autoattribute:: foreground_image_set
+   .. autoattribute:: image_set
+   .. autoattribute:: latitude
+   .. autoattribute:: longitude
+   .. autoattribute:: magnitude
+   .. autoattribute:: msr_community_id
+   .. autoattribute:: msr_component_id
+   .. autoattribute:: name
+   .. autoattribute:: opacity
+   .. autoattribute:: permission
+   .. autoattribute:: ra_hr
+   .. autoattribute:: rmeta
+   .. autoattribute:: rotation_deg
+   .. autoattribute:: thumbnail
+   .. autoattribute:: xmeta
+   .. autoattribute:: zoom_level
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: add_traits
+   .. automethod:: apply_to_xml
+   .. automethod:: as_imageset
+   .. automethod:: class_own_trait_events
+   .. automethod:: class_own_traits
+   .. automethod:: class_trait_names
+   .. automethod:: class_traits
+   .. automethod:: from_file
+   .. automethod:: from_text
+   .. automethod:: from_url
+   .. automethod:: from_xml
+   .. automethod:: has_trait
+   .. automethod:: hold_trait_notifications
+   .. automethod:: mutate_urls
+   .. automethod:: notify_change
+   .. automethod:: observe
+   .. automethod:: on_trait_change
+   .. automethod:: set_trait
+   .. automethod:: setup_instance
+   .. automethod:: to_xml
+   .. automethod:: to_xml_string
+   .. automethod:: trait_defaults
+   .. automethod:: trait_events
+   .. automethod:: trait_has_value
+   .. automethod:: trait_metadata
+   .. automethod:: trait_names
+   .. automethod:: trait_values
+   .. automethod:: traits
+   .. automethod:: unobserve
+   .. automethod:: unobserve_all
+   .. automethod:: write_xml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,17 @@ numpydoc_show_class_members = False
 
 nitpicky = True
 nitpick_ignore = [
+    # Traitlets stuff that we have to ignore. This is all due to our need to
+    # turn on :inherited-members: in api.rst due to a sphinx-automodapi bug (see
+    # comment in api.rst).
+    ('py:attr', 'class_init'),
+    ('py:attr', 'name'),
+    ('py:attr', 'this_class'),
+    ('py:class', 'traitlets.traitlets.HasDescriptors'),
+    ('py:class', 'traitlets.traitlets.MetaHasDescriptors'),
     ('py:class', 'traitlets.traitlets.MetaHasTraits'),
+    ('py:obj', 'handler'),
+    ('py:obj', 'remove'),
 ]
 
 default_role = 'obj'


### PR DESCRIPTION
I had been feeling like our API docs were missing a bunch of stuff that they were supposed to have, and it turns out that we're facing a bug in sphinx-automodapi:

https://github.com/astropy/sphinx-automodapi/issues/132

Here we work around the issue by turning on `:inherited-members:` everywhere. It pollutes our namespaces a bunch but is better than having nothing.