### PR TITLE
ci/azure-deployment.yml: fix Python publication

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -67,7 +67,7 @@ jobs:
         setupBuild: true
         setupCranko: true
     - bash: |
-        set -euo pipefail
+        set -eo pipefail  # no -u to work around Conda activation bug (2021 August)
         source activate-conda.sh
         set -x
         conda install -y twine


### PR DESCRIPTION
There's a recent change that causes a failure when the -u shell option is turned on.

Not testable without cutting a release, unfortunately, but I had to deal with the same bug in pywwt so I'm confident in the solution/workaround.