### PR TITLE
wwt_data_formats/imageset.py: fix offset_y for tiled images

### DIFF
--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -227,7 +227,8 @@ class ImageSet(LockedXmlTraits, UrlContainer):
 
     For tiled sky images, the offset is measured in *degrees*, and a value of
     zero means that the *center* of the image lands at the center of the
-    projection coordinate system.
+    projection coordinate system. Increasingly positive values move the image to
+    the right.
 
     As per the usual practice, offsets are always along the horizontal axis of
     the image in question, regardless of its :attr:`rotation <rotation_deg>` on
@@ -254,7 +255,8 @@ class ImageSet(LockedXmlTraits, UrlContainer):
 
     For tiled sky images, the offset is measured in *degrees*, and a value of
     zero means that the *center* of the image lands at the center of the
-    projection coordinate system.
+    projection coordinate system. Increasingly positive values move the image
+    upwards.
 
     As per the usual practice, offsets are always along the vertical axis of the
     image in question, regardless of its :attr:`rotation <rotation_deg>` on the
@@ -508,7 +510,7 @@ class ImageSet(LockedXmlTraits, UrlContainer):
         if self.tile_levels > 0:  # are we tiled?
             self.projection = ProjectionType.TAN
             self.offset_x = (width / 2 - refpix_x) * scale_x
-            self.offset_y = (height / 2 - refpix_y) * scale_y
+            self.offset_y = (refpix_y - height / 2) * scale_y
             self.base_degrees_per_tile = scale_y * 256 * 2**self.tile_levels
         else:
             self.projection = ProjectionType.SKY_IMAGE


### PR DESCRIPTION
I've convinced myself that I have the sign wrong. I think this hasn't showed up because in most cases the CRPIX2 value is close to the image center, and so the sign flip doesn't have a large effect. Hopefully.

@astrodavid10 If my analysis is correct, tilings of images should have been getting vertically misplaced if the reference pixels of those images were not near the image center. Can you think of any instances where you think you noticed that, or cases where the reference pixel was far away from the image center but the tiling seemed to be placed correctly?