### PR TITLE
wwt_data_formats/imageset.py: fix verification of rotations near 45 degrees

### DIFF
--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -474,11 +474,13 @@ class ImageSet(LockedXmlTraits, UrlContainer):
         if abs(scale_x - scale_y) / (scale_x + scale_y) > TOL:
             raise ValueError('WWT cannot express non-square pixels, which this WCS has')
 
-        if abs((cd1_1 - cd_sign * cd2_2) / cd_det) > TOL:
-            raise ValueError('WWT cannot express this CD matrix (1)')
+        det_scale = math.sqrt(abs(cd_det))
 
-        if abs((cd2_1 + cd_sign * cd1_2) / cd_det) > TOL:
-            raise ValueError('WWT cannot express this CD matrix (2)')
+        if abs((cd1_1 - cd_sign * cd2_2) / det_scale) > TOL:
+            raise ValueError(f'WWT cannot express this CD matrix (1; {cd1_1} {cd_sign} {cd2_2} {det_scale})')
+
+        if abs((cd2_1 + cd_sign * cd1_2) / det_scale) > TOL:
+            raise ValueError(f'WWT cannot express this CD matrix (2; {cd2_1} {cd_sign} {cd1_2} {det_scale})')
 
         # This is our best effort to make sure that the view centers on the
         # center of the image.

--- a/wwt_data_formats/tests/test_imageset.py
+++ b/wwt_data_formats/tests/test_imageset.py
@@ -263,6 +263,29 @@ def test_wcs_tiled_topdown():
     imgset.set_position_from_wcs(keywords, 1000, 1000)
 
 
+def test_wcs_45deg():
+    """
+    We had an issue with tolerance-checking with rotations near 145 degrees.
+    Example: NOIRLab image `noao-abell39hotelling`.
+    """
+
+    keywords = {
+        'CTYPE1': 'RA---TAN',
+        'CTYPE2': 'DEC--TAN',
+        'CRVAL1': 0,
+        'CRVAL2': 0,
+        'CRPIX1': 0,
+        'CRPIX2': 0,
+        'CD1_1': 0.00015024947791364,
+        'CD1_2': 0.00015517263725712,
+        'CD2_1': -0.00015521026392131,
+        'CD2_2': 0.00015021305386212,
+    }
+
+    imgset = imageset.ImageSet()
+    imgset.set_position_from_wcs(keywords, 1000, 1000)
+
+
 def test_misc_ser():
     expected_str = '''
 <ImageSet BandPass="Visible" BaseDegreesPerTile="0.0" BaseTileLevel="0"


### PR DESCRIPTION
The existing code was failing on NOIRLab `noao-abell39hotelling`, with the following inputs:

```
   Scale:
      * -0.000216021137021
      * 0.000215968768353
   Rotation: 134.06957586364
```

Because the CD matrix works out to:

```
(note order of subscripts here)
>> cd1_1, cd2_2 = 0.00015024947791364, 0.00015021305386212
>> cd1_2, cd2_1 = 0.00015517263725712, -0.00015521026392131
```

The determinant of the CD matrix has units [CD]^2, so our check was in units of [CD]^-1, exceeding the tolerance. I believe that the correct fix is to compare to the square root of the absolute determinant so that the dimensionality drops out. To be honest I forget why I was normalizing by the determinant here and not something like the RMS, but this new version should be strictly better than what we had before.