### PR TITLE
XML output tidying

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2019-2020 the .NET Foundation
+# Copyright 2019-2022 the .NET Foundation
 # Licensed under the MIT License
 
 from __future__ import absolute_import, division, print_function
@@ -7,86 +7,83 @@ from __future__ import absolute_import, division, print_function
 import os
 from setuptools import setup, Extension
 
+
 def get_long_desc():
     in_preamble = True
     lines = []
 
-    with open('README.md', 'rt', encoding='utf8') as f:
+    with open("README.md", "rt", encoding="utf8") as f:
         for line in f:
             if in_preamble:
-                if line.startswith('<!--pypi-begin-->'):
+                if line.startswith("<!--pypi-begin-->"):
                     in_preamble = False
             else:
-                if line.startswith('<!--pypi-end-->'):
+                if line.startswith("<!--pypi-end-->"):
                     break
                 else:
                     lines.append(line)
 
-    lines.append('''
+    lines.append(
+        """
 
 For more information, including installation instructions, please visit [the
 project homepage].
 
 [the project homepage]: https://wwt-data-formats.readthedocs.io/
-''')
-    return ''.join(lines)
+"""
+    )
+    return "".join(lines)
 
 
 setup_args = dict(
-    name = 'wwt_data_formats',  # cranko project-name
-    version = '0.dev0',  # cranko project-version
-    description = 'Low-level interface to AAS WorldWide Telescope data formats',
-    long_description = get_long_desc(),
-    long_description_content_type = 'text/markdown',
-    url = 'https://wwt-data-formats.readthedocs.io/',
-    license = 'MIT',
-    platforms = 'Linux, Mac OS X',
-
-    author = 'AAS WorldWide Telescope Team',
-    author_email = 'wwt@aas.org',
-
-    classifiers = [
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Scientific/Engineering :: Astronomy',
-        'Topic :: Scientific/Engineering :: Visualization',
+    name="wwt_data_formats",  # cranko project-name
+    version="0.dev0",  # cranko project-version
+    description="Low-level interface to AAS WorldWide Telescope data formats",
+    long_description=get_long_desc(),
+    long_description_content_type="text/markdown",
+    url="https://wwt-data-formats.readthedocs.io/",
+    license="MIT",
+    platforms="Linux, Mac OS X",
+    author="AAS WorldWide Telescope Team",
+    author_email="wwt@aas.org",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Scientific/Engineering :: Astronomy",
+        "Topic :: Scientific/Engineering :: Visualization",
     ],
-
-    packages = [
-        'wwt_data_formats',
-        'wwt_data_formats.tests',
+    packages=[
+        "wwt_data_formats",
+        "wwt_data_formats.tests",
     ],
-    include_package_data = True,
-
-    entry_points = {
-        'console_scripts': [
-            'wwtdatatool=wwt_data_formats.cli:entrypoint',
+    include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "wwtdatatool=wwt_data_formats.cli:entrypoint",
         ],
     },
-
-    install_requires = [
-        'requests',
-        'traitlets',
+    install_requires=[
+        "requests",
+        "traitlets",
     ],
-
-    extras_require = {
-        'test': [
-            'beautifulsoup4',
-            'mock',
-            'pytest-cov',
+    extras_require={
+        "test": [
+            "beautifulsoup4",
+            "mock",
+            "pytest-cov",
         ],
-        'docs': [
-            'astropy-sphinx-theme',
-            'numpydoc',
-            'sphinx',
-            'sphinx-automodapi',
+        "docs": [
+            "astropy-sphinx-theme",
+            "numpydoc",
+            "sphinx",
+            "sphinx-automodapi",
         ],
     },
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
-from setuptools import setup, Extension
+from setuptools import setup
 
 
 def get_long_desc():

--- a/wwt_data_formats/__init__.py
+++ b/wwt_data_formats/__init__.py
@@ -155,7 +155,15 @@ def _stringify_trait(trait_spec, value):
     if isinstance(trait_spec, UseEnum):
         return str(value.value)
 
-    return str(value)
+    if trait_spec.metadata.get("xml_omit_zero") and value == 0:
+        return ""
+
+    text = str(value)
+
+    if isinstance(value, float) and text.endswith(".0"):
+        text = text[:-2]
+
+    return text
 
 
 def _parse_trait(trait_spec, text):
@@ -482,6 +490,14 @@ class LockedXmlTraits(LockedDownTraits):
 
             if value is None:
                 continue
+
+            sky_type_filter = tspec.metadata.get("xml_if_sky_type_is")
+            if sky_type_filter is not None:
+                from .enums import DataSetType
+
+                cmp = self.data_set_type == DataSetType.SKY
+                if sky_type_filter != cmp:
+                    continue
 
             if xml_spec == XmlSer.ATTRIBUTE:
                 text = _stringify_trait(tspec, value)

--- a/wwt_data_formats/folder.py
+++ b/wwt_data_formats/folder.py
@@ -46,13 +46,13 @@ class Folder(LockedXmlTraits, UrlContainer):
         default_value=FolderType.UNSPECIFIED,
     ).tag(xml=XmlSer.attr("Type"))
     sub_type = Unicode("").tag(xml=XmlSer.attr("SubType"))
-    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"))
+    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"), xml_omit_zero=True)
     """The ID number of the WWT Community that this content came from."""
 
-    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"))
+    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"), xml_omit_zero=True)
     """The ID number of this content item on the WWT Communities system."""
 
-    permission = Int(0).tag(xml=XmlSer.attr("Permission"))
+    permission = Int(0).tag(xml=XmlSer.attr("Permission"), xml_omit_zero=True)
     "TBD."
 
     children = List(

--- a/wwt_data_formats/folder.py
+++ b/wwt_data_formats/folder.py
@@ -43,7 +43,7 @@ class Folder(LockedXmlTraits, UrlContainer):
     searchable = Bool(True).tag(xml=XmlSer.attr("Searchable"))
     type = UseEnum(
         FolderType,
-        default_value=FolderType.SKY,
+        default_value=FolderType.UNSPECIFIED,
     ).tag(xml=XmlSer.attr("Type"))
     sub_type = Unicode("").tag(xml=XmlSer.attr("SubType"))
     msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"))

--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2019-2021 the .NET Foundation
+# Copyright 2019-2022 the .NET Foundation
 # Licensed under the MIT License.
 
 """
@@ -208,7 +208,7 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     :attr:`offset_y` parameters do that.
 
     """
-    offset_x = Float(0.0).tag(xml=XmlSer.attr("OffsetX"))
+    offset_x = Float(0.0).tag(xml=XmlSer.attr("OffsetX"), xml_omit_zero=True)
     """
     The horizontal positioning of the image relative to its projection
     coordinate system.
@@ -236,7 +236,7 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     the sky.
 
     """
-    offset_y = Float(0.0).tag(xml=XmlSer.attr("OffsetY"))
+    offset_y = Float(0.0).tag(xml=XmlSer.attr("OffsetY"), xml_omit_zero=True)
     """The vertical positioning of the image relative to its projection
     coordinate system.
 
@@ -291,7 +291,7 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     generic = Bool(False).tag(xml=XmlSer.attr("Generic"))
     """TBD."""
 
-    mean_radius = Float(0.0).tag(xml=XmlSer.attr("MeanRadius"))
+    mean_radius = Float(0.0).tag(xml=XmlSer.attr("MeanRadius"), xml_omit_zero=True)
     """TBD."""
 
     credits = Unicode("").tag(xml=XmlSer.text_elem("Credits"))
@@ -312,25 +312,25 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     loaded from the XML.
     """
 
-    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"))
+    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"), xml_omit_zero=True)
     """The ID number of the WWT Community that this content came from."""
 
-    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"))
+    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"), xml_omit_zero=True)
     """The ID number of this content item on the WWT Communities system."""
 
-    permission = Int(0).tag(xml=XmlSer.attr("Permission"))
+    permission = Int(0).tag(xml=XmlSer.attr("Permission"), xml_omit_zero=True)
     "TBD."
 
-    pixel_cut_low = Float(0.0).tag(xml=XmlSer.attr("PixelCutLow"))
+    pixel_cut_low = Float(0.0).tag(xml=XmlSer.attr("PixelCutLow"), xml_omit_zero=True)
     """Suggested default low cutoff value when displaying FITS."""
 
-    pixel_cut_high = Float(0.0).tag(xml=XmlSer.attr("PixelCutHigh"))
+    pixel_cut_high = Float(0.0).tag(xml=XmlSer.attr("PixelCutHigh"), xml_omit_zero=True)
     """Suggested default high cutoff value when displaying FITS."""
 
-    data_min = Float(0.0).tag(xml=XmlSer.attr("DataMin"))
+    data_min = Float(0.0).tag(xml=XmlSer.attr("DataMin"), xml_omit_zero=True)
     """Lowest data value of a FITS file."""
 
-    data_max = Float(0.0).tag(xml=XmlSer.attr("DataMax"))
+    data_max = Float(0.0).tag(xml=XmlSer.attr("DataMax"), xml_omit_zero=True)
     """Highest data value of a FITS file."""
 
     def _tag_name(self):

--- a/wwt_data_formats/place.py
+++ b/wwt_data_formats/place.py
@@ -27,10 +27,10 @@ class Place(LockedXmlTraits, UrlContainer):
         xml=XmlSer.attr("DataSetType")
     )
     name = Unicode("").tag(xml=XmlSer.attr("Name"))
-    ra_hr = Float(0.0).tag(xml=XmlSer.attr("RA"))
-    dec_deg = Float(0.0).tag(xml=XmlSer.attr("Dec"))
-    latitude = Float(0.0).tag(xml=XmlSer.attr("Lat"))
-    longitude = Float(0.0).tag(xml=XmlSer.attr("Lng"))
+    ra_hr = Float(0.0).tag(xml=XmlSer.attr("RA"), xml_if_sky_type_is=True)
+    dec_deg = Float(0.0).tag(xml=XmlSer.attr("Dec"), xml_if_sky_type_is=True)
+    latitude = Float(0.0).tag(xml=XmlSer.attr("Lat"), xml_if_sky_type_is=False)
+    longitude = Float(0.0).tag(xml=XmlSer.attr("Lng"), xml_if_sky_type_is=False)
     constellation = UseEnum(Constellation, default_value=Constellation.UNSPECIFIED).tag(
         xml=XmlSer.attr("Constellation")
     )
@@ -38,14 +38,14 @@ class Place(LockedXmlTraits, UrlContainer):
         Classification, default_value=Classification.UNSPECIFIED
     ).tag(xml=XmlSer.attr("Classification"))
     magnitude = Float(0.0).tag(xml=XmlSer.attr("Magnitude"))
-    distance = Float(0.0).tag(xml=XmlSer.attr("Distance"))
+    distance = Float(0.0).tag(xml=XmlSer.attr("Distance"), xml_omit_zero=True)
     angular_size = Float(0.0).tag(xml=XmlSer.attr("AngularSize"))
     zoom_level = Float(0.0).tag(xml=XmlSer.attr("ZoomLevel"))
     rotation_deg = Float(0.0).tag(xml=XmlSer.attr("Rotation"))
     angle = Float(0.0).tag(xml=XmlSer.attr("Angle"))
     opacity = Float(100.0).tag(xml=XmlSer.attr("Opacity"))
-    dome_alt = Float(0.0).tag(xml=XmlSer.attr("DomeAlt"))
-    dome_az = Float(0.0).tag(xml=XmlSer.attr("DomeAz"))
+    dome_alt = Float(0.0).tag(xml=XmlSer.attr("DomeAlt"), xml_omit_zero=True)
+    dome_az = Float(0.0).tag(xml=XmlSer.attr("DomeAz"), xml_omit_zero=True)
     background_image_set = Instance(ImageSet, allow_none=True).tag(
         xml=XmlSer.wrapped_inner("BackgroundImageSet")
     )
@@ -82,13 +82,13 @@ class Place(LockedXmlTraits, UrlContainer):
 
     """
 
-    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"))
+    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"), xml_omit_zero=True)
     """The ID number of the WWT Community that this content came from."""
 
-    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"))
+    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"), xml_omit_zero=True)
     """The ID number of this content item on the WWT Communities system."""
 
-    permission = Int(0).tag(xml=XmlSer.attr("Permission"))
+    permission = Int(0).tag(xml=XmlSer.attr("Permission"), xml_omit_zero=True)
     "TBD."
 
     xmeta = Instance(

--- a/wwt_data_formats/place.py
+++ b/wwt_data_formats/place.py
@@ -7,9 +7,9 @@
 """
 from __future__ import absolute_import, division, print_function
 
-__all__ = '''
+__all__ = """
 Place
-'''.split()
+""".split()
 
 from argparse import Namespace
 from traitlets import Float, Instance, Int, Unicode, UseEnum
@@ -19,41 +19,43 @@ from .abcs import UrlContainer
 from .enums import Classification, Constellation, DataSetType
 from .imageset import ImageSet
 
+
 class Place(LockedXmlTraits, UrlContainer):
     """A place that can be visited."""
 
-    data_set_type = UseEnum(
-        DataSetType,
-        default_value = DataSetType.EARTH
-    ).tag(xml=XmlSer.attr('DataSetType'))
-    name = Unicode('').tag(xml=XmlSer.attr('Name'))
-    ra_hr = Float(0.0).tag(xml=XmlSer.attr('RA'))
-    dec_deg = Float(0.0).tag(xml=XmlSer.attr('Dec'))
-    latitude = Float(0.0).tag(xml=XmlSer.attr('Lat'))
-    longitude = Float(0.0).tag(xml=XmlSer.attr('Lng'))
-    constellation = UseEnum(
-        Constellation,
-        default_value = Constellation.UNSPECIFIED
-    ).tag(xml=XmlSer.attr('Constellation'))
+    data_set_type = UseEnum(DataSetType, default_value=DataSetType.EARTH).tag(
+        xml=XmlSer.attr("DataSetType")
+    )
+    name = Unicode("").tag(xml=XmlSer.attr("Name"))
+    ra_hr = Float(0.0).tag(xml=XmlSer.attr("RA"))
+    dec_deg = Float(0.0).tag(xml=XmlSer.attr("Dec"))
+    latitude = Float(0.0).tag(xml=XmlSer.attr("Lat"))
+    longitude = Float(0.0).tag(xml=XmlSer.attr("Lng"))
+    constellation = UseEnum(Constellation, default_value=Constellation.UNSPECIFIED).tag(
+        xml=XmlSer.attr("Constellation")
+    )
     classification = UseEnum(
-        Classification,
-        default_value = Classification.UNSPECIFIED
-    ).tag(xml=XmlSer.attr('Classification'))
-    magnitude = Float(0.0).tag(xml=XmlSer.attr('Magnitude'))
-    distance = Float(0.0).tag(xml=XmlSer.attr('Distance'))
-    angular_size = Float(0.0).tag(xml=XmlSer.attr('AngularSize'))
-    zoom_level = Float(0.0).tag(xml=XmlSer.attr('ZoomLevel'))
-    rotation_deg = Float(0.0).tag(xml=XmlSer.attr('Rotation'))
-    angle = Float(0.0).tag(xml=XmlSer.attr('Angle'))
-    opacity = Float(100.0).tag(xml=XmlSer.attr('Opacity'))
-    dome_alt = Float(0.0).tag(xml=XmlSer.attr('DomeAlt'))
-    dome_az = Float(0.0).tag(xml=XmlSer.attr('DomeAz'))
-    background_image_set = Instance(ImageSet, allow_none=True).tag(xml=XmlSer.wrapped_inner('BackgroundImageSet'))
-    foreground_image_set = Instance(ImageSet, allow_none=True).tag(xml=XmlSer.wrapped_inner('ForegroundImageSet'))
-    image_set = Instance(ImageSet, allow_none=True).tag(xml=XmlSer.inner('ImageSet'))
-    thumbnail = Unicode('').tag(xml=XmlSer.attr('Thumbnail'))
+        Classification, default_value=Classification.UNSPECIFIED
+    ).tag(xml=XmlSer.attr("Classification"))
+    magnitude = Float(0.0).tag(xml=XmlSer.attr("Magnitude"))
+    distance = Float(0.0).tag(xml=XmlSer.attr("Distance"))
+    angular_size = Float(0.0).tag(xml=XmlSer.attr("AngularSize"))
+    zoom_level = Float(0.0).tag(xml=XmlSer.attr("ZoomLevel"))
+    rotation_deg = Float(0.0).tag(xml=XmlSer.attr("Rotation"))
+    angle = Float(0.0).tag(xml=XmlSer.attr("Angle"))
+    opacity = Float(100.0).tag(xml=XmlSer.attr("Opacity"))
+    dome_alt = Float(0.0).tag(xml=XmlSer.attr("DomeAlt"))
+    dome_az = Float(0.0).tag(xml=XmlSer.attr("DomeAz"))
+    background_image_set = Instance(ImageSet, allow_none=True).tag(
+        xml=XmlSer.wrapped_inner("BackgroundImageSet")
+    )
+    foreground_image_set = Instance(ImageSet, allow_none=True).tag(
+        xml=XmlSer.wrapped_inner("ForegroundImageSet")
+    )
+    image_set = Instance(ImageSet, allow_none=True).tag(xml=XmlSer.inner("ImageSet"))
+    thumbnail = Unicode("").tag(xml=XmlSer.attr("Thumbnail"))
 
-    description = Unicode('').tag(xml=XmlSer.text_elem('Description'))
+    description = Unicode("").tag(xml=XmlSer.text_elem("Description"))
     """
     A description of the place, using HTML markup.
 
@@ -61,7 +63,7 @@ class Place(LockedXmlTraits, UrlContainer):
     and loaded from the XML.
     """
 
-    annotation = Unicode('').tag(xml=XmlSer.attr('Annotation'))
+    annotation = Unicode("").tag(xml=XmlSer.attr("Annotation"))
     """
     Annotation metadata for the place.
 
@@ -80,23 +82,23 @@ class Place(LockedXmlTraits, UrlContainer):
 
     """
 
-    msr_community_id = Int(0).tag(xml=XmlSer.attr('MSRCommunityId'))
+    msr_community_id = Int(0).tag(xml=XmlSer.attr("MSRCommunityId"))
     """The ID number of the WWT Community that this content came from."""
 
-    msr_component_id = Int(0).tag(xml=XmlSer.attr('MSRComponentId'))
+    msr_component_id = Int(0).tag(xml=XmlSer.attr("MSRComponentId"))
     """The ID number of this content item on the WWT Communities system."""
 
-    permission = Int(0).tag(xml=XmlSer.attr('Permission'))
+    permission = Int(0).tag(xml=XmlSer.attr("Permission"))
     "TBD."
 
     xmeta = Instance(
         Namespace,
-        args = (),
-        help = 'XML metadata - a namespace object for attaching arbitrary text to serialize',
-    ).tag(xml=XmlSer.ns_to_attr('X'))
+        args=(),
+        help="XML metadata - a namespace object for attaching arbitrary text to serialize",
+    ).tag(xml=XmlSer.ns_to_attr("X"))
 
     def _tag_name(self):
-        return 'Place'
+        return "Place"
 
     def mutate_urls(self, mutator):
         if self.thumbnail:

--- a/wwt_data_formats/tests/test_folder.py
+++ b/wwt_data_formats/tests/test_folder.py
@@ -62,19 +62,21 @@ CHILD1_XML_STRING = '''
 def fake_request_session_send(request, **kwargs):
     rv = Mock()
 
-    if request.url == 'http://example.com/root.wtml':
+    if request.url == "http://example.com/root.wtml":
         rv.text = ROOT_XML_STRING
-    elif request.url == 'http://example.com/child1.wtml':
+    elif request.url == "http://example.com/child1.wtml":
         rv.text = CHILD1_XML_STRING
     else:
-        raise Exception(f'unexpected URL to fake requests.Session.send(): {request.url}')
+        raise Exception(
+            f"unexpected URL to fake requests.Session.send(): {request.url}"
+        )
 
     return rv
 
 
 @pytest.fixture
 def fake_requests(mocker):
-    m = mocker.patch('requests.Session.send')
+    m = mocker.patch("requests.Session.send")
     m.side_effect = fake_request_session_send
 
 
@@ -128,8 +130,8 @@ def test_walk():
 
     expected = [
         (0, (), f0),
-        (1, (0, ), pl0),
-        (1, (1, ), f1),
+        (1, (0,), pl0),
+        (1, (1,), f1),
         (2, (1, 0), is0),
         (2, (1, 1), pl1),
     ]
@@ -140,7 +142,7 @@ def test_walk():
 
 def test_from_url():
     "Note that this test hits the network."
-    url = 'http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=ExploreRoot'
+    url = "http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=ExploreRoot"
     folder.Folder.from_url(url)  # just test that we don't crash
 
 
@@ -150,7 +152,7 @@ def test_fetch_tree(fake_requests, tempdir):
     def on_fetch(url):
         pass
 
-    folder.fetch_folder_tree('http://example.com/root.wtml', tempdir, on_fetch)
+    folder.fetch_folder_tree("http://example.com/root.wtml", tempdir, on_fetch)
 
     for item in folder.walk_cached_folder_tree(tempdir):
         pass
@@ -158,53 +160,61 @@ def test_fetch_tree(fake_requests, tempdir):
 
 def test_basic_url_mutation():
     f = folder.Folder()
-    f.url = '../updir/somewhere.wtml'
-    f.mutate_urls(folder.make_absolutizing_url_mutator('https://example.com/subdir/'))
-    assert f.url == 'https://example.com/updir/somewhere.wtml'
+    f.url = "../updir/somewhere.wtml"
+    f.mutate_urls(folder.make_absolutizing_url_mutator("https://example.com/subdir/"))
+    assert f.url == "https://example.com/updir/somewhere.wtml"
 
     from ..place import Place
     from ..imageset import ImageSet
 
     imgset = ImageSet()
-    imgset.url = 'image.jpg'
+    imgset.url = "image.jpg"
     p = Place()
     p.background_image_set = imgset
     f.children.append(p)
-    f.mutate_urls(folder.make_absolutizing_url_mutator('https://example.com/subdir/'))
+    f.mutate_urls(folder.make_absolutizing_url_mutator("https://example.com/subdir/"))
 
-    assert f.url == 'https://example.com/updir/somewhere.wtml'
-    assert imgset.url == 'https://example.com/subdir/image.jpg'
+    assert f.url == "https://example.com/updir/somewhere.wtml"
+    assert imgset.url == "https://example.com/subdir/image.jpg"
 
 
 def test_wtml_report():
     """Dumb smoketest."""
-    cli.entrypoint(['wtml', 'report', test_path('test1_rel.wtml')])
-    cli.entrypoint(['wtml', 'report', test_path('report_rel.wtml')])
+    cli.entrypoint(["wtml", "report", test_path("test1_rel.wtml")])
+    cli.entrypoint(["wtml", "report", test_path("report_rel.wtml")])
 
 
 def test_wtml_rewrite_disk(in_tempdir):
     f = folder.Folder()
-    f.url = 'sub%20dir/image.jpg'
+    f.url = "sub%20dir/image.jpg"
 
-    with open('index_rel.wtml', 'wt', encoding='utf8') as f_out:
+    with open("index_rel.wtml", "wt", encoding="utf8") as f_out:
         f.write_xml(f_out)
 
-    cli.entrypoint(['wtml', 'rewrite-disk', 'index_rel.wtml', 'index_disk.wtml'])
+    cli.entrypoint(["wtml", "rewrite-disk", "index_rel.wtml", "index_disk.wtml"])
 
-    f = folder.Folder.from_file('index_disk.wtml')
+    f = folder.Folder.from_file("index_disk.wtml")
     # abspath('') is not necessarily equal to abspath(in_tempdir), due to
     # symlinks and Windows filename shorterning.
-    assert f.url == os.path.join(os.path.abspath(''), 'sub dir', 'image.jpg')
+    assert f.url == os.path.join(os.path.abspath(""), "sub dir", "image.jpg")
 
 
 def test_wtml_rewrite_urls(in_tempdir):
     f = folder.Folder()
-    f.url = '../updir/somewhere.wtml'
+    f.url = "../updir/somewhere.wtml"
 
-    with open('index_rel.wtml', 'wt', encoding='utf8') as f_out:
+    with open("index_rel.wtml", "wt", encoding="utf8") as f_out:
         f.write_xml(f_out)
 
-    cli.entrypoint(['wtml', 'rewrite-urls', 'index_rel.wtml', 'https://example.com/subdir/', 'index.wtml'])
+    cli.entrypoint(
+        [
+            "wtml",
+            "rewrite-urls",
+            "index_rel.wtml",
+            "https://example.com/subdir/",
+            "index.wtml",
+        ]
+    )
 
-    f = folder.Folder.from_file('index.wtml')
-    assert f.url == 'https://example.com/updir/somewhere.wtml'
+    f = folder.Folder.from_file("index.wtml")
+    assert f.url == "https://example.com/updir/somewhere.wtml"

--- a/wwt_data_formats/tests/test_folder.py
+++ b/wwt_data_formats/tests/test_folder.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2020 the .NET Foundation
+# Copyright 2020-2022 the .NET Foundation
 # Licensed under the MIT License.
 
 from __future__ import absolute_import, division, print_function
@@ -31,33 +31,43 @@ def in_tempdir(tempdir):
     os.chdir(prev_dir)
 
 
-BASIC_XML_STRING = '''
-<Folder MSRCommunityId="0" MSRComponentId="0" Permission="0"
-        Browseable="True" Group="Explorer" Searchable="True" Type="Sky" />
-'''
+BASIC_XML_STRING = """
+<Folder Browseable="True" Group="Explorer" Searchable="True" />
+"""
 
-ROOT_XML_STRING = '''
-<Folder MSRCommunityId="0" MSRComponentId="0" Permission="0"
-        Browseable="True" Group="Explorer" Searchable="True" Type="Sky">
+ROOT_XML_STRING = """
+<Folder Browseable="True" Group="Explorer" Searchable="True" Type="Sky">
     <Folder Url="http://example.com/child1.wtml" />
-    <Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-        Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-        DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-        Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0">
-    </Place>
+    <Place
+        Angle="0"
+        AngularSize="0"
+        DataSetType="Earth"
+        Lat="0"
+        Lng="0"
+        Magnitude="0"
+        Opacity="100"
+        Rotation="0"
+        ZoomLevel="0"
+    />
 </Folder>
-'''
+"""
 
-CHILD1_XML_STRING = '''
-<Folder Name="Child1" MSRCommunityId="0" MSRComponentId="0" Permission="0"
-        Browseable="True" Group="Explorer" Searchable="True" Type="Sky">
-    <Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-        Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-        DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-        Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0">
-    </Place>
+CHILD1_XML_STRING = """
+<Folder Name="Child1" Browseable="True" Group="Explorer" Searchable="True" Type="Sky">
+    <Place
+        Angle="0"
+        AngularSize="0"
+        DataSetType="Earth"
+        Lat="0"
+        Lng="0"
+        Magnitude="0"
+        Opacity="100"
+        Rotation="0"
+        ZoomLevel="0"
+    />
 </Folder>
-'''
+"""
+
 
 def fake_request_session_send(request, **kwargs):
     rv = Mock()
@@ -93,21 +103,32 @@ def test_basic_xml():
 
 
 def test_children():
-    expected_str = '''
-<Folder Browseable="True" Group="Explorer" Searchable="True" Type="Sky"
-        MSRCommunityId="0" MSRComponentId="0" Permission="0">
-  <Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-         Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-         DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-         Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0">
-  </Place>
-  <Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-         Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-         DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-         Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0">
-  </Place>
+    expected_str = """
+<Folder Browseable="True" Group="Explorer" Searchable="True">
+    <Place
+        Angle="0"
+        AngularSize="0"
+        DataSetType="Earth"
+        Lat="0"
+        Lng="0"
+        Magnitude="0"
+        Opacity="100"
+        Rotation="0"
+        ZoomLevel="0"
+    />
+    <Place
+        Angle="0"
+        AngularSize="0"
+        DataSetType="Earth"
+        Lat="0"
+        Lng="0"
+        Magnitude="0"
+        Opacity="100"
+        Rotation="0"
+        ZoomLevel="0"
+    />
 </Folder>
-'''
+"""
     expected_xml = etree.fromstring(expected_str)
     f = folder.Folder()
     f.children.append(place.Place())

--- a/wwt_data_formats/tests/test_imageset.py
+++ b/wwt_data_formats/tests/test_imageset.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2020-2021 the .NET Foundation
+# Copyright 2020-2022 the .NET Foundation
 # Licensed under the MIT License.
 
 from __future__ import absolute_import, division, print_function
@@ -15,19 +15,32 @@ from .. import imageset, enums, stringify_xml_doc, write_xml_doc
 
 def test_basic_xml():
     expected_str = """
-<ImageSet MSRCommunityId="0" MSRComponentId="0" Permission="0"
-          BandPass="Gamma" BaseDegreesPerTile="0.1" BaseTileLevel="1"
-          BottomsUp="True" CenterX="1.234" CenterY="-0.31415"
-          DataSetType="Planet" ElevationModel="False" FileType=".PNG" Generic="False"
-          MeanRadius="0.0" Name="Test name"
-          OffsetX="100.1" OffsetY="100.2" Projection="SkyImage"
-          Rotation="5.4321" Sparse="False" StockSet="False" TileLevels="4"
-          PixelCutHigh="0.0" PixelCutLow="0.0" DataMax="0.0" DataMin="0.0"
-          Url="http://example.org/{0}" WidthFactor="2">
-  <Credits>Escaping &amp; Entities</Credits>
-  <CreditsUrl>https://example.org/credits</CreditsUrl>
-  <Description>Escaping &lt;entities&gt;</Description>
-  <ThumbnailUrl>https://example.org/thumbnail.jpg</ThumbnailUrl>
+<ImageSet
+    BandPass="Gamma"
+    BaseDegreesPerTile="0.1"
+    BaseTileLevel="1"
+    BottomsUp="True"
+    CenterX="1.234"
+    CenterY="-0.31415"
+    DataSetType="Planet"
+    ElevationModel="False"
+    FileType=".PNG"
+    Generic="False"
+    Name="Test name"
+    OffsetX="100.1"
+    OffsetY="100.2"
+    Projection="SkyImage"
+    Rotation="5.4321"
+    Sparse="False"
+    StockSet="False"
+    TileLevels="4"
+    Url="http://example.org/{0}"
+    WidthFactor="2"
+>
+    <Credits>Escaping &amp; Entities</Credits>
+    <CreditsUrl>https://example.org/credits</CreditsUrl>
+    <Description>Escaping &lt;entities&gt;</Description>
+    <ThumbnailUrl>https://example.org/thumbnail.jpg</ThumbnailUrl>
 </ImageSet>
 """
     expected_xml = etree.fromstring(expected_str)
@@ -101,16 +114,26 @@ def _check_wcs_roundtrip(imgset, height, source_kws):
 
 def test_wcs_1():
     expected_str = """
-<ImageSet BandPass="Visible" BaseDegreesPerTile="4.870732233333334e-05"
-          BaseTileLevel="0" BottomsUp="True" CenterX="83.633083"
-          CenterY="22.0145" DataSetType="Sky" ElevationModel="False"
-          FileType=".png" Generic="False" MeanRadius="0.0" MSRCommunityId="0"
-          MSRComponentId="0" OffsetX="1503.3507831457316"
-          OffsetY="1520.6994064339963" Permission="0" Projection="SkyImage"
-          Rotation="179.70963521481" Sparse="True" StockSet="False"
-          PixelCutHigh="0.0" PixelCutLow="0.0" DataMax="0.0" DataMin="0.0"
-          TileLevels="0" WidthFactor="2">
-</ImageSet>
+<ImageSet
+    BandPass="Visible"
+    BaseDegreesPerTile="4.870732233333334e-05"
+    BaseTileLevel="0"
+    BottomsUp="True"
+    CenterX="83.633083"
+    CenterY="22.0145"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".png"
+    Generic="False"
+    OffsetX="1503.3507831457316"
+    OffsetY="1520.6994064339963"
+    Projection="SkyImage"
+    Rotation="179.70963521481"
+    Sparse="True"
+    StockSet="False"
+    TileLevels="0"
+    WidthFactor="2"
+/>
 """
     expected_xml = etree.fromstring(expected_str)
 
@@ -140,13 +163,27 @@ def test_wcs_1():
 
 def test_wcs_only_two_pc_values():
     expected_str = """
-<ImageSet BandPass="Visible" BaseDegreesPerTile="0.003888888888889" BaseTileLevel="0"
-             BottomsUp="False" CenterX="233.73705402943" CenterY="23.506972488486" DataMax="0.0" DataMin="0.0"
-             DataSetType="Sky" ElevationModel="False" FileType=".fits" Generic="False" MSRCommunityId="0"
-             MSRComponentId="0" MeanRadius="0.0" Name="herschel_spire_tiled" OffsetX="130.5" OffsetY="126.5"
-             Permission="0" PixelCutHigh="0.0" PixelCutLow="0.0" Projection="SkyImage"
-             Rotation="-0.0" Sparse="True" StockSet="False" TileLevels="0" WidthFactor="2">
-</ImageSet>
+<ImageSet
+    BandPass="Visible"
+    BaseDegreesPerTile="0.003888888888889"
+    BaseTileLevel="0"
+    BottomsUp="False"
+    CenterX="233.73705402943"
+    CenterY="23.506972488486"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".fits"
+    Generic="False"
+    Name="herschel_spire_tiled"
+    OffsetX="130.5"
+    OffsetY="126.5"
+    Projection="SkyImage"
+    Rotation="-0"
+    Sparse="True"
+    StockSet="False"
+    TileLevels="0"
+    WidthFactor="2"
+/>
 """
     expected_xml = etree.fromstring(expected_str)
 
@@ -377,21 +414,13 @@ def test_wcs_offsety():
     BottomsUp="False"
     CenterX="97.99720145"
     CenterY="4.722029196"
-    DataMax="0.0"
-    DataMin="0.0"
     DataSetType="Sky"
     ElevationModel="False"
     FileType=".png"
     Generic="False"
-    MeanRadius="0.0"
-    MSRCommunityId="0"
-    MSRComponentId="0"
     Name="noao-02190_300x240"
     OffsetX="163.6018453"
     OffsetY="93.40002848"
-    Permission="0"
-    PixelCutHigh="0.0"
-    PixelCutLow="0.0"
     Projection="SkyImage"
     Rotation="-1.2477001179999867"
     Sparse="True"
@@ -434,21 +463,13 @@ def test_wcs_offsety():
     BottomsUp="True"
     CenterX="97.99720145"
     CenterY="4.722029196"
-    DataMax="0.0"
-    DataMin="0.0"
     DataSetType="Sky"
     ElevationModel="False"
     FileType=".png"
     Generic="False"
-    MeanRadius="0.0"
-    MSRCommunityId="0"
-    MSRComponentId="0"
     Name="noao-02190_300x240_botup"
     OffsetX="163.6018453"
     OffsetY="146.59997152"
-    Permission="0"
-    PixelCutHigh="0.0"
-    PixelCutLow="0.0"
     Projection="SkyImage"
     Rotation="178.75229988200002"
     Sparse="True"
@@ -488,21 +509,13 @@ def test_wcs_offsety():
     BottomsUp="False"
     CenterX="97.99720145"
     CenterY="4.722029196"
-    DataMax="0.0"
-    DataMin="0.0"
     DataSetType="Sky"
     ElevationModel="False"
     FileType=".png"
     Generic="False"
-    MeanRadius="0.0"
-    MSRCommunityId="0"
-    MSRComponentId="0"
     Name="noao-02190_300x240_tiled"
     OffsetX="-0.12173735991406849"
     OffsetY="0.23807139657986032"
-    Permission="0"
-    PixelCutHigh="0.0"
-    PixelCutLow="0.0"
     Projection="Tan"
     Rotation="-1.2477001179999867"
     Sparse="True"
@@ -523,12 +536,25 @@ def test_wcs_offsety():
 
 def test_misc_ser():
     expected_str = """
-<ImageSet BandPass="Visible" BaseDegreesPerTile="0.0" BaseTileLevel="0"
-          BottomsUp="False" CenterX="0.0" CenterY="0.0" DataMax="0.0" DataMin="0.0" DataSetType="Sky" ElevationModel="False"
-          FileType=".png" Generic="False" MeanRadius="0.0" MSRCommunityId="0" MSRComponentId="0"
-          OffsetX="0.0" OffsetY="0.0" Permission="0" PixelCutHigh="0.0" PixelCutLow="0.0"
-          Projection="SkyImage" Rotation="0.0" Sparse="True" StockSet="False" TileLevels="0"
-          Url="http://example.com/unspecified" WidthFactor="2" />
+<ImageSet
+    BandPass="Visible"
+    BaseDegreesPerTile="0"
+    BaseTileLevel="0"
+    BottomsUp="False"
+    CenterX="0"
+    CenterY="0"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".png"
+    Generic="False"
+    Projection="SkyImage"
+    Rotation="0"
+    Sparse="True"
+    StockSet="False"
+    TileLevels="0"
+    Url="http://example.com/unspecified"
+    WidthFactor="2"
+/>
 """
     expected_xml = etree.fromstring(expected_str)
 

--- a/wwt_data_formats/tests/test_place.py
+++ b/wwt_data_formats/tests/test_place.py
@@ -1,24 +1,29 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2020 the .NET Foundation
+# Copyright 2020-2022 the .NET Foundation
 # Licensed under the MIT License.
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
 from xml.etree import ElementTree as etree
 
 from . import assert_xml_trees_equal
-from .. import enums, imageset, place
+from .. import imageset, place
 
 
 def test_basic_xml():
-    expected_str = '''
-<Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-       Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-       DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-       Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0">
-</Place>
-'''
+    expected_str = """
+<Place
+    Angle="0"
+    AngularSize="0"
+    DataSetType="Earth"
+    Lat="0"
+    Lng="0"
+    Magnitude="0"
+    Opacity="100"
+    Rotation="0"
+    ZoomLevel="0"
+/>
+"""
     expected_xml = etree.fromstring(expected_str)
     pl = place.Place()
     observed_xml = pl.to_xml()
@@ -26,14 +31,21 @@ def test_basic_xml():
 
 
 def test_xmeta():
-    expected_str = '''
-<Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-       Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-       DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-       Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0" XExtra1="hello"
-       XExtra2="1">
-</Place>
-'''
+    expected_str = """
+<Place
+    Angle="0"
+    AngularSize="0"
+    DataSetType="Earth"
+    Lat="0"
+    Lng="0"
+    Magnitude="0"
+    Opacity="100"
+    Rotation="0"
+    ZoomLevel="0"
+    XExtra1="hello"
+    XExtra2="1"
+/>
+"""
     expected_xml = etree.fromstring(expected_str)
     pl = place.Place()
     pl.xmeta.Extra1 = "hello"
@@ -43,41 +55,81 @@ def test_xmeta():
 
 
 def test_nesting():
-    expected_str = '''
-<Place MSRCommunityId="0" MSRComponentId="0" Permission="0"
-       Angle="0.0" AngularSize="0.0" DataSetType="Earth" Dec="0.0" Distance="0.0"
-       DomeAlt="0.0" DomeAz="0.0" Lat="0.0" Lng="0.0" Magnitude="0.0"
-       Opacity="100.0" RA="0.0" Rotation="0.0" ZoomLevel="0.0">
-  <BackgroundImageSet>
-    <ImageSet MSRCommunityId="0" MSRComponentId="0" Permission="0"
-              PixelCutHigh="0.0" PixelCutLow="0.0" DataMax="0.0" DataMin="0.0"
-              BandPass="Visible" BaseDegreesPerTile="0.0" BaseTileLevel="0"
-              BottomsUp="False" CenterX="0.0" CenterY="0.0" DataSetType="Sky" ElevationModel="False"
-              FileType=".png" Generic="False" MeanRadius="0.0" OffsetX="0.0" OffsetY="0.0" Projection="SkyImage"
-              Rotation="0.0" Sparse="True" StockSet="False" TileLevels="0"
-              Url="http://example.com/background" WidthFactor="2">
-    </ImageSet>
-  </BackgroundImageSet>
-  <ForegroundImageSet>
-    <ImageSet MSRCommunityId="0" MSRComponentId="0" Permission="0"
-              PixelCutHigh="0.0" PixelCutLow="0.0" DataMax="0.0" DataMin="0.0"
-              BandPass="Visible" BaseDegreesPerTile="0.0" BaseTileLevel="0"
-              BottomsUp="False" CenterX="0.0" CenterY="0.0" DataSetType="Sky" ElevationModel="False"
-              FileType=".png" Generic="False" MeanRadius="0.0" OffsetX="0.0" OffsetY="0.0" Projection="SkyImage"
-              Rotation="0.0" Sparse="True" StockSet="False" TileLevels="0"
-              Url="http://example.com/foreground" WidthFactor="2">
-    </ImageSet>
-  </ForegroundImageSet>
-  <ImageSet MSRCommunityId="0" MSRComponentId="0" Permission="0"
-            PixelCutHigh="0.0" PixelCutLow="0.0" DataMax="0.0" DataMin="0.0"
-            BandPass="Visible" BaseDegreesPerTile="0.0" BaseTileLevel="0"
-            BottomsUp="False" CenterX="0.0" CenterY="0.0" DataSetType="Sky" ElevationModel="False"
-            FileType=".png" Generic="False" MeanRadius="0.0" OffsetX="0.0" OffsetY="0.0" Projection="SkyImage"
-            Rotation="0.0" Sparse="True" StockSet="False" TileLevels="0"
-            Url="http://example.com/unspecified" WidthFactor="2">
-  </ImageSet>
+    expected_str = """
+<Place
+    Angle="0"
+    AngularSize="0"
+    DataSetType="Earth"
+    Lat="0"
+    Lng="0"
+    Magnitude="0"
+    Opacity="100"
+    Rotation="0"
+    ZoomLevel="0"
+>
+    <BackgroundImageSet>
+        <ImageSet
+            BandPass="Visible"
+            BaseDegreesPerTile="0"
+            BaseTileLevel="0"
+            BottomsUp="False"
+            CenterX="0"
+            CenterY="0"
+            DataSetType="Sky"
+            ElevationModel="False"
+            FileType=".png"
+            Generic="False"
+            Projection="SkyImage"
+            Rotation="0"
+            Sparse="True"
+            StockSet="False"
+            TileLevels="0"
+            Url="http://example.com/background"
+            WidthFactor="2"
+        />
+    </BackgroundImageSet>
+    <ForegroundImageSet>
+        <ImageSet
+            BandPass="Visible"
+            BaseDegreesPerTile="0"
+            BaseTileLevel="0"
+            BottomsUp="False"
+            CenterX="0"
+            CenterY="0"
+            DataSetType="Sky"
+            ElevationModel="False"
+            FileType=".png"
+            Generic="False"
+            Projection="SkyImage"
+            Rotation="0"
+            Sparse="True"
+            StockSet="False"
+            TileLevels="0"
+            Url="http://example.com/foreground"
+            WidthFactor="2"
+        />
+    </ForegroundImageSet>
+    <ImageSet
+        BandPass="Visible"
+        BaseDegreesPerTile="0"
+        BaseTileLevel="0"
+        BottomsUp="False"
+        CenterX="0"
+        CenterY="0"
+        DataSetType="Sky"
+        ElevationModel="False"
+        FileType=".png"
+        Generic="False"
+        Projection="SkyImage"
+        Rotation="0"
+        Sparse="True"
+        StockSet="False"
+        TileLevels="0"
+        Url="http://example.com/unspecified"
+        WidthFactor="2"
+    />
 </Place>
-'''
+"""
     expected_xml = etree.fromstring(expected_str)
     pl = place.Place()
     pl.image_set = imageset.ImageSet()

--- a/wwt_data_formats/tests/test_place.py
+++ b/wwt_data_formats/tests/test_place.py
@@ -36,7 +36,7 @@ def test_xmeta():
 '''
     expected_xml = etree.fromstring(expected_str)
     pl = place.Place()
-    pl.xmeta.Extra1 = 'hello'
+    pl.xmeta.Extra1 = "hello"
     pl.xmeta.Extra2 = 1
     observed_xml = pl.to_xml()
     assert_xml_trees_equal(expected_xml, observed_xml)
@@ -81,10 +81,10 @@ def test_nesting():
     expected_xml = etree.fromstring(expected_str)
     pl = place.Place()
     pl.image_set = imageset.ImageSet()
-    pl.image_set.url = 'http://example.com/unspecified'
+    pl.image_set.url = "http://example.com/unspecified"
     pl.foreground_image_set = imageset.ImageSet()
-    pl.foreground_image_set.url = 'http://example.com/foreground'
+    pl.foreground_image_set.url = "http://example.com/foreground"
     pl.background_image_set = imageset.ImageSet()
-    pl.background_image_set.url = 'http://example.com/background'
+    pl.background_image_set.url = "http://example.com/background"
     observed_xml = pl.to_xml()
     assert_xml_trees_equal(expected_xml, observed_xml)


### PR DESCRIPTION
These changes tidy up our XML output to match more closely the patterns of existing WWT WTML serializations, without altering semantics (as best I can tell).

Also lots of `black` reformatting that inflates the diffs.