### PR TITLE
Make sure that we emit imageset XML compatible with the Windows app's loader

### DIFF
--- a/wwt_data_formats/__init__.py
+++ b/wwt_data_formats/__init__.py
@@ -486,6 +486,7 @@ class LockedXmlTraits(LockedDownTraits):
 
         for tname, tspec in self.traits(xml=lambda a: a is not None).items():
             xml_spec, *xml_data = tspec.metadata["xml"]
+            even_if_empty = tspec.metadata.get("xml_even_if_empty", False)
             value = getattr(self, tname)
 
             if value is None:
@@ -501,13 +502,13 @@ class LockedXmlTraits(LockedDownTraits):
 
             if xml_spec == XmlSer.ATTRIBUTE:
                 text = _stringify_trait(tspec, value)
-                if not text:
+                if not text and not even_if_empty:
                     continue
 
                 elem.set(xml_data[0], text)
             elif xml_spec == XmlSer.TEXT_ELEM:
                 text = _stringify_trait(tspec, value)
-                if not text:
+                if not text and not even_if_empty:
                     continue
 
                 sub = elem.find(xml_data[0])

--- a/wwt_data_formats/__init__.py
+++ b/wwt_data_formats/__init__.py
@@ -552,7 +552,7 @@ class LockedXmlTraits(LockedDownTraits):
                         if elem[idx].tag != child._tag_name():
                             raise RuntimeError(
                                 "serializing flexible list to existing XML data, "
-                                f"but it looks like child #{i} changed"
+                                f"but it looks like child #{idx} changed"
                             )
                         child._serialize_xml(elem[idx])
                     else:
@@ -578,7 +578,7 @@ class LockedXmlTraits(LockedDownTraits):
                         if wrapper[idx].tag != child._tag_name():
                             raise RuntimeError(
                                 "serializing flexible list to existing XML data, "
-                                f"but it looks like child #{i} changed"
+                                f"but it looks like child #{idx} changed"
                             )
                         child._serialize_xml(wrapper[idx])
                     else:

--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -44,14 +44,14 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     reference_frame = Unicode("").tag(xml=XmlSer.attr("ReferenceFrame"))
     """TBD."""
 
-    name = Unicode("").tag(xml=XmlSer.attr("Name"))
+    name = Unicode("").tag(xml=XmlSer.attr("Name"), xml_even_if_empty=True)
     """A name used to refer to this imageset.
 
     Various parts of the WWT internals reference imagesets by this name, so
     it should be distinctive.
 
     """
-    url = Unicode("").tag(xml=XmlSer.attr("Url"))
+    url = Unicode("").tag(xml=XmlSer.attr("Url"), xml_even_if_empty=True)
     """The URL of the image data.
 
     Either a URL or a URL template. URLs that are exposed to the engine should
@@ -84,7 +84,9 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     This should be zero except for special circumstances.
 
     """
-    quad_tree_map = Unicode("").tag(xml=XmlSer.attr("QuadTreeMap"))
+    quad_tree_map = Unicode("").tag(
+        xml=XmlSer.attr("QuadTreeMap"), xml_even_if_empty=True
+    )
     """TBD."""
 
     tile_levels = Int(0).tag(xml=XmlSer.attr("TileLevels"))
@@ -114,7 +116,7 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     be set to 0.016 * 2048 / 1200 = 0.0273.
 
     """
-    file_type = Unicode(".png").tag(xml=XmlSer.attr("FileType"))
+    file_type = Unicode(".png").tag(xml=XmlSer.attr("FileType"), xml_even_if_empty=True)
     """
     The extension(s) of the image file(s) in this set.
 
@@ -300,7 +302,9 @@ class ImageSet(LockedXmlTraits, UrlContainer):
     credits_url = Unicode("").tag(xml=XmlSer.text_elem("CreditsUrl"))
     """A URL giving the source of the image or more information about its creation."""
 
-    thumbnail_url = Unicode("").tag(xml=XmlSer.text_elem("ThumbnailUrl"))
+    thumbnail_url = Unicode("").tag(
+        xml=XmlSer.text_elem("ThumbnailUrl"), xml_even_if_empty=True
+    )
     """A URL to a standard WWT thumbnail representation of this imageset."""
 
     description = Unicode("").tag(xml=XmlSer.text_elem("Description"))

--- a/wwt_data_formats/tests/test_place.py
+++ b/wwt_data_formats/tests/test_place.py
@@ -79,14 +79,18 @@ def test_nesting():
             ElevationModel="False"
             FileType=".png"
             Generic="False"
+            Name=""
             Projection="SkyImage"
+            QuadTreeMap=""
             Rotation="0"
             Sparse="True"
             StockSet="False"
             TileLevels="0"
             Url="http://example.com/background"
             WidthFactor="2"
-        />
+        >
+            <ThumbnailUrl></ThumbnailUrl>
+        </ImageSet>
     </BackgroundImageSet>
     <ForegroundImageSet>
         <ImageSet
@@ -100,14 +104,18 @@ def test_nesting():
             ElevationModel="False"
             FileType=".png"
             Generic="False"
+            Name=""
             Projection="SkyImage"
+            QuadTreeMap=""
             Rotation="0"
             Sparse="True"
             StockSet="False"
             TileLevels="0"
             Url="http://example.com/foreground"
             WidthFactor="2"
-        />
+        >
+            <ThumbnailUrl></ThumbnailUrl>
+        </ImageSet>
     </ForegroundImageSet>
     <ImageSet
         BandPass="Visible"
@@ -120,14 +128,18 @@ def test_nesting():
         ElevationModel="False"
         FileType=".png"
         Generic="False"
+        Name=""
         Projection="SkyImage"
+        QuadTreeMap=""
         Rotation="0"
         Sparse="True"
         StockSet="False"
         TileLevels="0"
         Url="http://example.com/unspecified"
         WidthFactor="2"
-    />
+    >
+        <ThumbnailUrl></ThumbnailUrl>
+    </ImageSet>
 </Place>
 """
     expected_xml = etree.fromstring(expected_str)


### PR DESCRIPTION
The app will actually refuse to start up if the `imagesets.xml` file contains imagesets that are missing certain XML items. Make sure those are always there.