### PR TITLE
ci/zenodo.json5: set the Zenodo concept record ID

### DIFF
--- a/ci/zenodo.json5
+++ b/ci/zenodo.json5
@@ -2,7 +2,7 @@
 // and https://developers.zenodo.org/#representation
 
 {
-  conceptrecid: 'new-for:0.15.0',
+  conceptrecid: '7011176',
 
   metadata: {
     upload_type: 'software',


### PR DESCRIPTION
Now that we've published our first release, we log the "concept" ID so that subsequent releases can be related to it.