### PR TITLE
wwt_data_formats/imageset.py: accept the TPV projection

### DIFF
--- a/wwt_data_formats/imageset.py
+++ b/wwt_data_formats/imageset.py
@@ -426,7 +426,9 @@ class ImageSet(LockedXmlTraits, UrlContainer):
         will do its best to detect and reject them.
         """
 
-        if headers["CTYPE1"] != "RA---TAN" or headers["CTYPE2"] != "DEC--TAN":
+        if headers["CTYPE1"] not in ("RA---TAN", "RA---TPV") or headers[
+            "CTYPE2"
+        ] not in ("DEC--TAN", "DEC--TPV"):
             raise ValueError("WCS coordinates must be in an equatorial/TAN projection")
 
         # Figure out the stuff we need from the headers.

--- a/wwt_data_formats/tests/test_imageset.py
+++ b/wwt_data_formats/tests/test_imageset.py
@@ -166,6 +166,14 @@ def test_wcs_1():
 
     _check_wcs_roundtrip(imgset, 3000, wcs_keywords)
 
+    # Also check with TPV headers, which we allow for DASCH
+
+    wcs_keywords["CTYPE1"] = "RA---TPV"
+    wcs_keywords["CTYPE2"] = "DEC--TPV"
+    imgset.set_position_from_wcs(wcs_keywords, 3000, 3000)
+    observed_xml = imgset.to_xml()
+    assert_xml_trees_equal(expected_xml, observed_xml)
+
 
 def test_wcs_only_two_pc_values():
     expected_str = """


### PR DESCRIPTION
This is non-standard but comes up in DASCH data. It's TAN plus distortions, so if we just treat it like TAN, the results for the WCS conversion routine should be OK.