### PR TITLE
wwt_data_formats/imageset.py: fix positioning of odd-sized studies

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
       set -euo pipefail
       source activate-conda.sh
       set -x
-      \conda create -y -n build setuptools pip
+      \conda create -y -n build setuptools pip python=3.10
       conda activate build
       pip install $BASH_WORKSPACE/sdist/*.tar.gz
     displayName: Install from sdist


### PR DESCRIPTION
As explored in WorldWideTelescope/wwt-webgl-engine#212, there were times when "study" FITS images were landing a half-pixel off from their intended locations. After some digging, I realized that the issue is that odd-sized images have to be shifted a half-pixel relative to their "ideal" centering in the tiling pixelization. We need to take account of that here.