### PR TITLE
Temporarily disable Zenodo

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -15,14 +15,14 @@ jobs:
 - ${{ if parameters.isMainDev }}:
   - job: dummy_setup_only
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     steps:
     - template: azure-job-setup.yml
 
 - ${{ if parameters.isRelease }}:
   - job: branch_and_tag
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     variables:
     - group: Deployment Credentials
     steps:
@@ -41,7 +41,7 @@ jobs:
   - job: github_releases
     dependsOn: branch_and_tag # otherwise, GitHub creates the tag itself
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     variables:
     - group: Deployment Credentials
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   - job: python_publish
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     variables:
     - group: Deployment Credentials
     steps:
@@ -88,7 +88,7 @@ jobs:
   #
   # - job: zenodo_publish
   #   pool:
-  #     vmImage: ubuntu-20.04
+  #     vmImage: ubuntu-latest
   #   variables:
   #   - group: Deployment Credentials
   #

--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -83,23 +83,26 @@ jobs:
       env:
         PYPI_TOKEN: $(PYPI_TOKEN)
 
-  - job: zenodo_publish
-    pool:
-      vmImage: ubuntu-20.04
-    variables:
-    - group: Deployment Credentials
-
-    steps:
-    - template: azure-job-setup.yml
-      parameters:
-        setupCranko: true
-
-    - bash: cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 $BASH_WORKSPACE/sdist/*.tar.gz
-      displayName: Upload source tarball
-      env:
-        ZENODO_TOKEN: $(ZENODO_TOKEN)
-
-    - bash: cranko zenodo publish --metadata=ci/zenodo.json5
-      displayName: Publish to Zenodo
-      env:
-        ZENODO_TOKEN: $(ZENODO_TOKEN)
+  # 2023 Oct: temporarily disabling Zenodo; they have just updated their API and broken
+  # everything, and we want to ge a release out.
+  #
+  # - job: zenodo_publish
+  #   pool:
+  #     vmImage: ubuntu-20.04
+  #   variables:
+  #   - group: Deployment Credentials
+  #
+  #   steps:
+  #   - template: azure-job-setup.yml
+  #     parameters:
+  #       setupCranko: true
+  #
+  #   - bash: cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 $BASH_WORKSPACE/sdist/*.tar.gz
+  #     displayName: Upload source tarball
+  #     env:
+  #       ZENODO_TOKEN: $(ZENODO_TOKEN)
+  #
+  #   - bash: cranko zenodo publish --metadata=ci/zenodo.json5
+  #     displayName: Publish to Zenodo
+  #     env:
+  #       ZENODO_TOKEN: $(ZENODO_TOKEN)

--- a/ci/azure-sdist.yml
+++ b/ci/azure-sdist.yml
@@ -29,11 +29,14 @@ jobs:
   - bash: cranko release-workflow apply-versions
     displayName: Apply Cranko versions
 
-  - bash: cranko zenodo preregister --metadata=ci/zenodo.json5 wwt_data_formats wwt_data_formats/cli.py CHANGELOG.md
-    displayName: "Preregister Zenodo DOI"
-    ${{ if and(eq(variables['Build.SourceBranchName'], 'rc'), ne(variables['build.reason'], 'PullRequest')) }}:
-      env:
-        ZENODO_TOKEN: $(ZENODO_TOKEN)
+  # 2023 Oct: temporarily disabling Zenodo; they have just updated their API and broken
+  # everything, and we want to ge a release out.
+  #
+  #- bash: cranko zenodo preregister --metadata=ci/zenodo.json5 wwt_data_formats wwt_data_formats/cli.py CHANGELOG.md
+  #  displayName: "Preregister Zenodo DOI"
+  #  ${{ if and(eq(variables['Build.SourceBranchName'], 'rc'), ne(variables['build.reason'], 'PullRequest')) }}:
+  #    env:
+  #      ZENODO_TOKEN: $(ZENODO_TOKEN)
 
   - bash: |
       set -xeuo pipefail


### PR DESCRIPTION
It looks like Zenodo's big update broke all of their APIs, so, good job there. Disable the Zenodo stuff since we want to get a release out here. At some point soon I'll sit down and update Cranko to work with whatever the new system is.

This means that our release artifacts will report junk DOIs, which isn't ideal, but life will go on.