### PR TITLE
Re-enable Zenodo deposition

### DIFF
--- a/ci/azure-build-and-test.yml
+++ b/ci/azure-build-and-test.yml
@@ -6,12 +6,12 @@ parameters:
   default:
 
   - name: linux_37
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
     vars:
       PYTHON_SERIES: "3.7"
 
   - name: linux_38
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
     vars:
       PYTHON_SERIES: "3.8"
 
@@ -68,7 +68,7 @@ jobs:
 
 - job: coverage
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:
@@ -97,7 +97,7 @@ jobs:
 
 - job: docs
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - template: azure-job-setup.yml
     parameters:

--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -83,26 +83,23 @@ jobs:
       env:
         PYPI_TOKEN: $(PYPI_TOKEN)
 
-  # 2023 Oct: temporarily disabling Zenodo; they have just updated their API and broken
-  # everything, and we want to ge a release out.
-  #
-  # - job: zenodo_publish
-  #   pool:
-  #     vmImage: ubuntu-latest
-  #   variables:
-  #   - group: Deployment Credentials
-  #
-  #   steps:
-  #   - template: azure-job-setup.yml
-  #     parameters:
-  #       setupCranko: true
-  #
-  #   - bash: cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 $BASH_WORKSPACE/sdist/*.tar.gz
-  #     displayName: Upload source tarball
-  #     env:
-  #       ZENODO_TOKEN: $(ZENODO_TOKEN)
-  #
-  #   - bash: cranko zenodo publish --metadata=ci/zenodo.json5
-  #     displayName: Publish to Zenodo
-  #     env:
-  #       ZENODO_TOKEN: $(ZENODO_TOKEN)
+  - job: zenodo_publish
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+    - group: Deployment Credentials
+
+    steps:
+    - template: azure-job-setup.yml
+      parameters:
+        setupCranko: true
+
+    - bash: cranko zenodo upload-artifacts --metadata=ci/zenodo.json5 $BASH_WORKSPACE/sdist/*.tar.gz
+      displayName: Upload source tarball
+      env:
+        ZENODO_TOKEN: $(ZENODO_TOKEN)
+
+    - bash: cranko zenodo publish --metadata=ci/zenodo.json5
+      displayName: Publish to Zenodo
+      env:
+        ZENODO_TOKEN: $(ZENODO_TOKEN)

--- a/ci/azure-sdist.yml
+++ b/ci/azure-sdist.yml
@@ -4,7 +4,7 @@ jobs:
 
 - job: sdist
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
 
   # Need Zenodo credentials to generate DOIs during formal releases. Try not to
   # provide credentials otherwise, in case of malicious PRs. But note that such

--- a/ci/azure-sdist.yml
+++ b/ci/azure-sdist.yml
@@ -29,14 +29,11 @@ jobs:
   - bash: cranko release-workflow apply-versions
     displayName: Apply Cranko versions
 
-  # 2023 Oct: temporarily disabling Zenodo; they have just updated their API and broken
-  # everything, and we want to ge a release out.
-  #
-  #- bash: cranko zenodo preregister --metadata=ci/zenodo.json5 wwt_data_formats wwt_data_formats/cli.py CHANGELOG.md
-  #  displayName: "Preregister Zenodo DOI"
-  #  ${{ if and(eq(variables['Build.SourceBranchName'], 'rc'), ne(variables['build.reason'], 'PullRequest')) }}:
-  #    env:
-  #      ZENODO_TOKEN: $(ZENODO_TOKEN)
+  - bash: cranko zenodo preregister --metadata=ci/zenodo.json5 wwt_data_formats wwt_data_formats/cli.py CHANGELOG.md
+    displayName: "Preregister Zenodo DOI"
+    ${{ if and(eq(variables['Build.SourceBranchName'], 'rc'), ne(variables['build.reason'], 'PullRequest')) }}:
+      env:
+        ZENODO_TOKEN: $(ZENODO_TOKEN)
 
   - bash: |
       set -xeuo pipefail


### PR DESCRIPTION
Cranko has been fixed up, so we can restore the Zenodo integration.

This reverts commit 60d901b8ab316ef811f1712fa0639a6d4414ab7d.