### PR TITLE
wwt_data_formats/imageset.py: be less picky about WCS when we're TOAST

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ required dependencies will get installed automatically. The `README in the Git
 repository`_ lists the current dependencies if you would like to see an
 explict list.
 
-.. _README in the Git repository: https://github.com/WorldWideTelescope/wwt_data_formats/#readme
+.. _README in the Git repository: https://github.com/WorldWideTelescope/wwt_data_formats/
 
 
 Installing the developer version


### PR DESCRIPTION
If we're using `set_position_from_wcs()` for a TOAST imageset, the details of the WCS aren't very important, since we're just using it to obtain basic centering and sizing info. So, we can skip various checks about square pixels and such.

Also improve an error message that referred to a non-positive CD determinant when it was really checking for 0 or NaN (in effect). We are OK with negative determinants if the image isn't tiled.